### PR TITLE
Update board.js to always keep filter settings #235

### DIFF
--- a/assets/js/board.js
+++ b/assets/js/board.js
@@ -213,6 +213,14 @@ Kanboard.Board = (function() {
                 item.style.opacity = "0.2";
             }
         });
+        
+		//Save filter settings for active project to localStorage
+		if (typeof(Storage) !== "undefined") {
+		    var projectId = $('#board').data('project-id');
+			localStorage.setItem(projectId + "_form-user_id", selectedUserId);
+			localStorage.setItem(projectId + "_form-category_id", selectedCategoryId);
+			localStorage.setItem(projectId + "_filter-due-date", ~~(filterDueDate));
+		}
     }
 
     // Load filter events
@@ -227,6 +235,22 @@ Kanboard.Board = (function() {
             filter_apply();
             e.preventDefault();
         });
+        
+		// Get and set filters from localStorage for active project
+		if (typeof(Storage) !== "undefined") {
+		    var projectId = $('#board').data('project-id');
+			$("#form-user_id").val(localStorage.getItem(projectId + "_form-user_id") || -1);
+			$("#form-category_id").val(localStorage.getItem(projectId + "_form-category_id") || -1);
+			
+			if (+localStorage.getItem(projectId + "_filter-due-date")) {
+				$("#filter-due-date").addClass("filter-on");
+			} else {
+				$("#filter-due-date").removeClass("filter-on");
+			}
+			
+			// apply filters on load
+	    	filter_apply();
+		}
     }
 
     return {


### PR DESCRIPTION
Save filter settings to localStorage everytime filter_apply() is called.

Get and set filters from localStorage when filter_load_events() is called.

This improves the user experience when browsing tasks on a filtered board. No need to set the filters each time the board loads.

Perhaps a checkbox option to initialize this functionality but I think it should be default behavior.