### PR TITLE
fix invalid HTML when linking to URLs with numeric fragment identifiers

### DIFF
--- a/app/Core/Helper.php
+++ b/app/Core/Helper.php
@@ -7,6 +7,9 @@ use Parsedown;
 
 class _ParsedownKanboard extends Parsedown
 {
+    private $link;
+    private $helper;
+    
     public function __construct($link, $helper) 
     {
         $this->link = $link;
@@ -18,7 +21,7 @@ class _ParsedownKanboard extends Parsedown
     protected function identifyTaskLink($Excerpt)
     {
         // Replace task #123 by a link to the task
-        if (preg_match('!#(\d+)!i', $Excerpt['text'], $matches))
+        if (!empty($this->link) && preg_match('!#(\d+)!i', $Excerpt['text'], $matches))
         {
             $url = $this->helper->u($this->link['controller'],
                                     $this->link['action'],

--- a/tests/units/HelperTest.php
+++ b/tests/units/HelperTest.php
@@ -18,7 +18,7 @@ class HelperTest extends Base
         );
 
         $this->assertEquals(
-            '<p>Task <a href="?controller=a&amp;action=b&amp;c=d&amp;task_id=123" class="" title="" >#123</a></p>',
+            '<p>Task <a href="?controller=a&amp;action=b&amp;c=d&amp;task_id=123">#123</a></p>',
             $h->markdown('Task #123', array('controller' => 'a', 'action' => 'b', 'params' => array('c' => 'd')))
         );
     }


### PR DESCRIPTION
Fix for #544.

The code tried to convert task numbers to links by applying a regex substitution to the HTML output of Parsedown. This can sometimes break the HTML.

One example is links to URLs with a fragment identifier that starts with a number, such as http://stackoverflow.com/questions/1732348/regex-match-open-tags-except-xhtml-self-contained-tags/1732454#1732454

The fix is to add the additional processing to the markdown renderer itself, so it's only applied to appropriate parts of the text, and never to the generated HTML tags.