### PR TITLE
Added column description in Task Boards.

### DIFF
--- a/app/Controller/Base.php
+++ b/app/Controller/Base.php
@@ -312,4 +312,23 @@ abstract class Base
 
         return $project;
     }
+    
+    /**
+     * Common method to get a column
+     *
+     * @access protected
+     * @param  integer      $column_id    Default column id
+     * @return array
+     */
+    protected function getColumn()
+    {
+    	$column_id = $this->request->getIntegerParam('column_id', $column_id);
+    	$column = $this->board->getColumn($column_id);
+    
+        if (! $column ) {
+            $this->notfound();
+        }
+    
+    	return $column;
+    }
 }

--- a/app/Controller/Board.php
+++ b/app/Controller/Board.php
@@ -205,6 +205,7 @@ class Board extends Base
 
         foreach ($columns as $column) {
             $values['title['.$column['id'].']'] = $column['title'];
+            $values['description['.$column['id'].']'] = $column['description'];
             $values['task_limit['.$column['id'].']'] = $column['task_limit'] ?: null;
         }
 
@@ -233,6 +234,7 @@ class Board extends Base
             $columns_list[$column['id']] = $column['title'];
             $values['title['.$column['id'].']'] = isset($data['title'][$column['id']]) ? $data['title'][$column['id']] : '';
             $values['task_limit['.$column['id'].']'] = isset($data['task_limit'][$column['id']]) ? $data['task_limit'][$column['id']] : 0;
+            $values['description['.$column['id'].']'] = isset($data['description'][$column['id']]) ? $data['description'][$column['id']] : '';
         }
 
         list($valid, $errors) = $this->board->validateModification($columns_list, $values);
@@ -271,7 +273,7 @@ class Board extends Base
 
         if ($valid) {
 
-            if ($this->board->addColumn($project['id'], $data['title'])) {
+            if ($this->board->addColumn($project['id'], $data['title'],$data['description'])) {
                 $this->session->flash(t('Board updated successfully.'));
                 $this->response->redirect('?controller=board&action=edit&project_id='.$project['id']);
             }
@@ -449,7 +451,7 @@ class Board extends Base
     }
 
     /**
-     * Display the description
+     * Display task description
      *
      * @access public
      */
@@ -460,5 +462,19 @@ class Board extends Base
         $this->response->html($this->template->render('board/description', array(
             'task' => $task
         )));
+    }
+    
+    /**
+     * Display column description
+     *
+     * @access public
+     */
+    public function columndescription()
+    {
+    	$column = $this->getColumn();
+    
+    	$this->response->html($this->template->render('board/columndescription', array(
+    			'column' => $column
+    	)));
     }
 }

--- a/app/Model/Board.php
+++ b/app/Model/Board.php
@@ -73,6 +73,7 @@ class Board extends Base
                 'position' => ++$position,
                 'project_id' => $project_id,
                 'task_limit' => $column['task_limit'],
+            	'description' => $column['description'],
             );
 
             if (! $this->db->table(self::TABLE)->save($values)) {
@@ -108,16 +109,18 @@ class Board extends Base
      * @access public
      * @param  integer   $project_id    Project id
      * @param  string    $title         Column title
+     * @param  string    $description   Column description
      * @param  integer   $task_limit    Task limit
      * @return boolean|integer
      */
-    public function addColumn($project_id, $title, $task_limit = 0)
+    public function addColumn($project_id, $title, $description, $task_limit = 0)
     {
         $values = array(
             'project_id' => $project_id,
             'title' => $title,
             'task_limit' => $task_limit,
             'position' => $this->getLastColumnPosition($project_id) + 1,
+        	'description' => $description,
         );
 
         return $this->persist(self::TABLE, $values);
@@ -134,7 +137,7 @@ class Board extends Base
     {
         $columns = array();
 
-        foreach (array('title', 'task_limit') as $field) {
+        foreach (array('title', 'description', 'task_limit') as $field) {
             foreach ($values[$field] as $column_id => $value) {
                 $columns[$column_id][$field] = $value;
             }
@@ -143,7 +146,7 @@ class Board extends Base
         $this->db->startTransaction();
 
         foreach ($columns as $column_id => $values) {
-            $this->updateColumn($column_id, $values['title'], (int) $values['task_limit']);
+            $this->updateColumn($column_id, $values['title'], (int) $values['task_limit'], $values['description']);
         }
 
         $this->db->closeTransaction();
@@ -160,11 +163,12 @@ class Board extends Base
      * @param  integer   $task_limit    Task limit
      * @return boolean
      */
-    public function updateColumn($column_id, $title, $task_limit = 0)
+    public function updateColumn($column_id, $title, $task_limit = 0, $description = "")
     {
         return $this->db->table(self::TABLE)->eq('id', $column_id)->update(array(
             'title' => $title,
             'task_limit' => $task_limit,
+        	'description' => $description,
         ));
     }
 

--- a/app/Schema/Mysql.php
+++ b/app/Schema/Mysql.php
@@ -5,7 +5,12 @@ namespace Schema;
 use PDO;
 use Core\Security;
 
-const VERSION = 41;
+const VERSION = 42;
+
+function version_42($pdo)
+{
+	$pdo->exec('ALTER TABLE columns ADD COLUMN description TEXT');
+}
 
 function version_41($pdo)
 {

--- a/app/Schema/Postgres.php
+++ b/app/Schema/Postgres.php
@@ -5,7 +5,12 @@ namespace Schema;
 use PDO;
 use Core\Security;
 
-const VERSION = 22;
+const VERSION = 23;
+
+function version_23($pdo)
+{
+	$pdo->exec('ALTER TABLE columns ADD COLUMN description TEXT');
+}
 
 function version_22($pdo)
 {

--- a/app/Schema/Sqlite.php
+++ b/app/Schema/Sqlite.php
@@ -5,7 +5,12 @@ namespace Schema;
 use Core\Security;
 use PDO;
 
-const VERSION = 40;
+const VERSION = 41;
+
+function version_41($pdo)
+{
+	$pdo->exec('ALTER TABLE columns ADD COLUMN description TEXT');
+}
 
 function version_40($pdo)
 {

--- a/app/Template/board/columndescription.php
+++ b/app/Template/board/columndescription.php
@@ -1,0 +1,5 @@
+<section class="tooltip-large">
+<div class="markdown">
+    <?= $this->markdown($column['description']) ?>
+</div>
+</section>

--- a/app/Template/board/edit.php
+++ b/app/Template/board/edit.php
@@ -11,6 +11,7 @@
         <tr>
             <th><?= t('Position') ?></th>
             <th><?= t('Column title') ?></th>
+            <th><?= t('Description') ?></th>
             <th><?= t('Task limit') ?></th>
             <th><?= t('Actions') ?></th>
         </tr>
@@ -18,6 +19,7 @@
         <tr>
             <td><?= $this->formLabel('#'.++$i, 'title['.$column['id'].']', array('title="column_id='.$column['id'].'"')) ?></td>
             <td><?= $this->formText('title['.$column['id'].']', $values, $errors, array('required', 'maxlength="50"')) ?></td>
+            <td><?= $this->formTextarea('description['.$column['id'].']', $values, $errors, array('placeholder="'.t('description').'"')) ?></td>
             <td><?= $this->formNumber('task_limit['.$column['id'].']', $values, $errors, array('placeholder="'.t('limit').'"')) ?></td>
             <td>
                 <ul>
@@ -54,6 +56,9 @@
 
     <?= $this->formLabel(t('Title'), 'title') ?>
     <?= $this->formText('title', $values, $errors, array('required', 'maxlength="50"')) ?>
+    <?= $this->formLabel(t('Description'), 'description') ?>
+    <?= $this->formTextarea('description', $values, $errors) ?>
+    <div class="form-help"><a href="http://kanboard.net/documentation/syntax-guide" target="_blank" rel="noreferrer"><?= t('Write your text in Markdown') ?></a></div>
 
     <div class="form-actions">
         <input type="submit" value="<?= t('Add this column') ?>" class="btn btn-blue"/>

--- a/app/Template/board/swimlane.php
+++ b/app/Template/board/swimlane.php
@@ -12,6 +12,12 @@
         <?php endif ?>
 
         <?= $this->e($column['title']) ?>
+        
+        <?php if (! empty($column['description'])): ?>
+            <span title="<?= t('Description') ?>" class="task-board-tooltip" data-href="<?= $this->u('board', 'columndescription', array('column_id' => $column['id'], 'project_id' => $column['project_id'])) ?>">
+                <i class="fa fa-file-text-o"></i>
+            </span>
+        <?php endif ?>
 
         <?php if ($column['task_limit']): ?>
             <span title="<?= t('Task limit') ?>" class="task-limit">


### PR DESCRIPTION
Each column in a board may have description which is free form and textual in nature. This field can be used for many purposes like:

* A general description of this column.
* Entry criteria: When a task qualifies to move to this column.
* Checklist for exiting this column.

This feature adds a column 'column.description' of type text. One can add/edit descriptions to columns from [project]-> Edit Board link.

In the board view, one icon appears next to the column name if a description was added to it. A pop-over on that icon shows the description. Markdown is supported in description however, Write/Preview options are not shown.

### Screenshot
![image](https://cloud.githubusercontent.com/assets/7455931/5888872/17420172-a435-11e4-8268-d785d87fa22f.png)

