### PR TITLE
fix user parameter name for createSubtask, updateSubtask in json-RPC API

### DIFF
--- a/docs/api-json-rpc.markdown
+++ b/docs/api-json-rpc.markdown
@@ -1879,7 +1879,7 @@ Response example:
 - Parameters:
     - **task_id** (integer, required)
     - **title** (integer, required)
-    - **assignee_id** (int, optional)
+    - **user_id** (int, optional)
     - **time_estimated** (int, optional)
     - **time_spent** (int, optional)
     - **status** (int, optional)
@@ -1996,7 +1996,7 @@ Response example:
     - **id** (integer, required)
     - **task_id** (integer, required)
     - **title** (integer, optional)
-    - **assignee_id** (integer, optional)
+    - **user_id** (integer, optional)
     - **time_estimated** (integer, optional)
     - **time_spent** (integer, optional)
     - **status** (integer, optional)

--- a/scripts/kanboard.py
+++ b/scripts/kanboard.py
@@ -975,7 +975,7 @@ class Kanboard():
         
         return response.json()['result']
     
-    def createSubtask(self, task_id, title, assignee_id=None, time_estimated=None, time_spent=None, status=None):
+    def createSubtask(self, task_id, title, user_id=None, time_estimated=None, time_spent=None, status=None):
         kid = self._getId()   
         params = {
                  "jsonrpc": "2.0",
@@ -988,8 +988,8 @@ class Kanboard():
         }
         
         #optional parameters
-        if assignee_id is not None:
-            params['params']["assignee_id"] = assignee_id
+        if user_id is not None:
+            params['params']["user_id"] = user_id
         if time_estimated is not None:
             params['params']["time_estimated"] = time_estimated
         if time_spent is not None:
@@ -1040,7 +1040,7 @@ class Kanboard():
         
         return response.json()['result']
     
-    def updateSubtask(self, subtask_id, task_id, title=None, assignee_id=None, time_estimated=None, time_spent=None, status=None):
+    def updateSubtask(self, subtask_id, task_id, title=None, user_id=None, time_estimated=None, time_spent=None, status=None):
         kid = self._getId()   
         params = {
                  "jsonrpc": "2.0",
@@ -1055,8 +1055,8 @@ class Kanboard():
         #optional parameters        
         if title is not None:
             params['params']["title"] = title
-        if assignee_id is not None:
-            params['params']["assignee_id"] = assignee_id
+        if user_id is not None:
+            params['params']["user_id"] = user_id
         if time_estimated is not None:
             params['params']["time_estimated"] = time_estimated
         if time_spent is not None:


### PR DESCRIPTION
Changing the documentation and python example to match what the server code says: "user_id", not "assignee_id".