### PR TITLE
Allow public access to colors stylesheet.

### DIFF
--- a/app/Model/Acl.php
+++ b/app/Model/Acl.php
@@ -22,6 +22,7 @@ class Acl extends Base
         'board' => array('readonly'),
         'project' => array('feed'),
         'webhook' => '*',
+        'app' => array('colors'),
     );
 
     /**

--- a/tests/units/AclTest.php
+++ b/tests/units/AclTest.php
@@ -37,6 +37,7 @@ class AclTest extends Base
         $acl = new Acl($this->container);
         $this->assertTrue($acl->isPublicAction('board', 'readonly'));
         $this->assertFalse($acl->isPublicAction('board', 'show'));
+        $this->assertTrue($acl->isPublicAction('app', 'colors'));
     }
 
     public function testAdminActions()


### PR DESCRIPTION
The CSS stylesheet at ?controller=app&action=colors is currently not available if the user is not logged in.

As a result of this, any public boards viewed in read-only mode to a user who is not (or has not been) logged in do not display the task cards in color.

This is a change to the ACL to allow access.