### PR TITLE
This adds a quick comment creation link in the task menu on board.

### DIFF
--- a/app/Controller/Comment.php
+++ b/app/Controller/Comment.php
@@ -41,6 +41,7 @@ class Comment extends Base
     public function create(array $values = array(), array $errors = array())
     {
         $task = $this->getTask();
+        $ajax = $this->request->isAjax() || $this->request->getIntegerParam('ajax');
 
         if (empty($values)) {
             $values = array(
@@ -49,14 +50,23 @@ class Comment extends Base
             );
         }
 
+        if ($ajax) {
+        	$this->response->html($this->template->render('comment/create', array(
+            'values' => $values,
+            'errors' => $errors,
+            'task' => $task,
+            'ajax' => $ajax
+        )));
+        } else {
         $this->response->html($this->taskLayout('comment/create', array(
             'values' => $values,
             'errors' => $errors,
             'task' => $task,
             'title' => t('Add a comment')
         )));
+        }
     }
-
+    
     /**
      * Add a comment
      *
@@ -66,7 +76,8 @@ class Comment extends Base
     {
         $task = $this->getTask();
         $values = $this->request->getValues();
-
+        $ajax = $this->request->isAjax() || $this->request->getIntegerParam('ajax');
+        
         list($valid, $errors) = $this->comment->validateCreation($values);
 
         if ($valid) {
@@ -78,7 +89,12 @@ class Comment extends Base
                 $this->session->flashError(t('Unable to create your comment.'));
             }
 
-            $this->response->redirect('?controller=task&action=show&task_id='.$task['id'].'&project_id='.$task['project_id'].'#comments');
+            if ($ajax) {
+            	$this->response->redirect('?controller=board&action=show&project_id='.$task['project_id']);
+            }
+            else {
+            	$this->response->redirect('?controller=task&action=show&task_id='.$task['id'].'&project_id='.$task['project_id'].'#comments');
+            }
         }
 
         $this->create($values, $errors);

--- a/app/Template/board/task.php
+++ b/app/Template/board/task.php
@@ -20,6 +20,7 @@
                     <li><i class="fa fa-user"></i> <?= $this->a(t('Change assignee'), 'board', 'changeAssignee', array('task_id' => $task['id'], 'project_id' => $task['project_id']), false, 'task-board-popover') ?></li>
                     <li><i class="fa fa-tag"></i> <?= $this->a(t('Change category'), 'board', 'changeCategory', array('task_id' => $task['id'], 'project_id' => $task['project_id']), false, 'task-board-popover') ?></li>
                     <li><i class="fa fa-align-left"></i> <?= $this->a(t('Change description'), 'task', 'description', array('task_id' => $task['id'], 'project_id' => $task['project_id']), false, 'task-board-popover') ?></li>
+                    <li><i class="fa fa-comment-o"></i> <?= $this->a(t('Add a comment'), 'comment', 'create', array('task_id' => $task['id'], 'project_id' => $task['project_id']), false, 'task-board-popover') ?></li>
                     <li><i class="fa fa-pencil-square-o"></i> <?= $this->a(t('Edit this task'), 'task', 'edit', array('task_id' => $task['id'], 'project_id' => $task['project_id']), false, 'task-board-popover') ?></li>
                     <li><i class="fa fa-close"></i> <?= $this->a(t('Close this task'), 'task', 'close', array('task_id' => $task['id'], 'project_id' => $task['project_id'], 'redirect' => 'board'), false, 'task-board-popover') ?></li>
                 </ul>

--- a/app/Template/comment/create.php
+++ b/app/Template/comment/create.php
@@ -2,7 +2,7 @@
     <h2><?= t('Add a comment') ?></h2>
 </div>
 
-<form method="post" action="<?= $this->u('comment', 'save', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>" autocomplete="off">
+<form method="post" action="<?= $this->u('comment', 'save', array('task_id' => $task['id'], 'project_id' => $task['project_id'], 'ajax' => $ajax)) ?>" autocomplete="off">
     <?= $this->formCsrf() ?>
     <?= $this->formHidden('task_id', $values) ?>
     <?= $this->formHidden('user_id', $values) ?>
@@ -30,7 +30,11 @@
         <input type="submit" value="<?= t('Save') ?>" class="btn btn-blue"/>
         <?php if (! isset($skip_cancel)): ?>
             <?= t('or') ?>
-            <?= $this->a(t('cancel'), 'task', 'show', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>
+            <?php if ($ajax): ?>
+                <?= $this->a(t('cancel'), 'board', 'show', array('project_id' => $task['project_id'])) ?>
+            <?php else: ?>
+                <?= $this->a(t('cancel'), 'task', 'show', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>
+        <?php endif ?>
         <?php endif ?>
     </div>
 </form>


### PR DESCRIPTION
In our environment it's one of the most frequently used action. It may be useful to others as well.

*Just a thought, do we need 'Change assignee' and 'Change Category' in the menu? One can open them by clicking of the 'assigned' name or 'category' box. Then the menu is less crowded*
![image](https://cloud.githubusercontent.com/assets/7455931/6217192/62ea1560-b637-11e4-9184-cd06240220c8.png)
 