### PR TITLE
Add new actions to move issue when the assignee is changed.

### DIFF
--- a/app/Action/TaskMoveColumnAssigned.php
+++ b/app/Action/TaskMoveColumnAssigned.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Action;
+
+use Model\Task;
+
+/**
+ * Move a task to another column when an assignee is set
+ *
+ * @package action
+ * @author  Francois Ferrand
+ */
+class TaskMoveColumnAssigned extends Base
+{
+    /**
+     * Get the list of compatible events
+     *
+     * @access public
+     * @return array
+     */
+    public function getCompatibleEvents()
+    {
+        return array(
+            Task::EVENT_ASSIGNEE_CHANGE,
+        );
+    }
+
+    /**
+     * Get the required parameter for the action (defined by the user)
+     *
+     * @access public
+     * @return array
+     */
+    public function getActionRequiredParameters()
+    {
+        return array(
+            'src_column_id' => t('From column'),
+            'dest_column_id' => t('To column')
+        );
+    }
+
+    /**
+     * Get the required parameter for the event
+     *
+     * @access public
+     * @return string[]
+     */
+    public function getEventRequiredParameters()
+    {
+        return array(
+            'task_id',
+            'column_id',
+            'project_id',
+            'owner_id'
+        );
+    }
+
+    /**
+     * Execute the action (move the task to another column)
+     *
+     * @access public
+     * @param  array   $data   Event data dictionary
+     * @return bool            True if the action was executed or false when not executed
+     */
+    public function doAction(array $data)
+    {
+        $original_task = $this->taskFinder->getById($data['task_id']);
+
+        return $this->taskPosition->movePosition(
+            $data['project_id'],
+            $data['task_id'],
+            $this->getParam('dest_column_id'),
+            $original_task['position'],
+            $original_task['swimlane_id'],
+            false
+        );
+    }
+
+    /**
+     * Check if the event data meet the action condition
+     *
+     * @access public
+     * @param  array   $data   Event data dictionary
+     * @return bool
+     */
+    public function hasRequiredCondition(array $data)
+    {
+        return $data['column_id'] == $this->getParam('src_column_id') &&
+               $data['owner_id'];
+    }
+}

--- a/app/Action/TaskMoveColumnUnAssigned.php
+++ b/app/Action/TaskMoveColumnUnAssigned.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Action;
+
+use Model\Task;
+
+/**
+ * Move a task to another column when an assignee is cleared
+ *
+ * @package action
+ * @author  Francois Ferrand
+ */
+class TaskMoveColumnUnAssigned extends Base
+{
+    /**
+     * Get the list of compatible events
+     *
+     * @access public
+     * @return array
+     */
+    public function getCompatibleEvents()
+    {
+        return array(
+            Task::EVENT_ASSIGNEE_CHANGE
+        );
+    }
+
+    /**
+     * Get the required parameter for the action (defined by the user)
+     *
+     * @access public
+     * @return array
+     */
+    public function getActionRequiredParameters()
+    {
+        return array(
+            'src_column_id' => t('From column'),
+            'dest_column_id' => t('To column')
+        );
+    }
+
+    /**
+     * Get the required parameter for the event
+     *
+     * @access public
+     * @return string[]
+     */
+    public function getEventRequiredParameters()
+    {
+        return array(
+            'task_id',
+            'column_id',
+            'project_id',
+            'owner_id'
+        );
+    }
+
+    /**
+     * Execute the action (move the task to another column)
+     *
+     * @access public
+     * @param  array   $data   Event data dictionary
+     * @return bool            True if the action was executed or false when not executed
+     */
+    public function doAction(array $data)
+    {
+        $original_task = $this->taskFinder->getById($data['task_id']);
+
+        return $this->taskPosition->movePosition(
+            $data['project_id'],
+            $data['task_id'],
+            $this->getParam('dest_column_id'),
+            $original_task['position'],
+            $original_task['swimlane_id'],
+            false
+        );
+    }
+
+    /**
+     * Check if the event data meet the action condition
+     *
+     * @access public
+     * @param  array   $data   Event data dictionary
+     * @return bool
+     */
+    public function hasRequiredCondition(array $data)
+    {
+        return $data['column_id'] == $this->getParam('src_column_id') &&
+               !$data['owner_id'];
+    }
+}

--- a/app/Model/Action.php
+++ b/app/Model/Action.php
@@ -45,6 +45,8 @@ class Action extends Base
             'TaskAssignCurrentUser' => t('Assign the task to the person who does the action'),
             'TaskDuplicateAnotherProject' => t('Duplicate the task to another project'),
             'TaskMoveAnotherProject' => t('Move the task to another project'),
+            'TaskMoveColumnAssigned' => t('Move the task to another column when assigned to a user'),
+            'TaskMoveColumnUnAssigned' => t('Move the task to another column when assignee is cleared'),
             'TaskAssignColorUser' => t('Assign a color to a specific user'),
             'TaskAssignColorCategory' => t('Assign automatically a color based on a category'),
             'TaskAssignCategoryColor' => t('Assign automatically a category based on a color'),

--- a/app/Model/TaskPosition.php
+++ b/app/Model/TaskPosition.php
@@ -23,7 +23,7 @@ class TaskPosition extends Base
      * @param  integer    $swimlane_id       Swimlane id
      * @return boolean
      */
-    public function movePosition($project_id, $task_id, $column_id, $position, $swimlane_id = 0)
+    public function movePosition($project_id, $task_id, $column_id, $position, $swimlane_id = 0, $fire_events = true)
     {
         $original_task = $this->taskFinder->getById($task_id);
 
@@ -35,7 +35,8 @@ class TaskPosition extends Base
                 $this->calculateAndSave($project_id, 0, $column_id, 1, $original_task['swimlane_id']);
             }
 
-            $this->fireEvents($original_task, $column_id, $position, $swimlane_id);
+            if ($fire_events)
+                $this->fireEvents($original_task, $column_id, $position, $swimlane_id);
         }
 
         return $result;


### PR DESCRIPTION
This will *not* fire the task_moved events, to avoid triggering other auto-assign actions.
This does not seem ideal, but I see no easy way to implement this properly (e.g. checking the event
stack).