### PR TITLE
Escape markdown code in column tooltips.

### DIFF
--- a/app/Template/app/projects.php
+++ b/app/Template/app/projects.php
@@ -22,7 +22,7 @@
 
                 <?= $this->a($this->e($project['name']), 'board', 'show', array('project_id' => $project['id'])) ?>
                 <?php if (! empty($project['description'])): ?>
-                    <span class="column-tooltip" title='<?= $this->markdown($project['description']) ?>'>
+                    <span class="column-tooltip" title='<?= $this->e($this->markdown($project['description'])) ?>'>
                         <i class="fa fa-info-circle"></i>
                     </span>
                 <?php endif ?>

--- a/app/Template/board/edit.php
+++ b/app/Template/board/edit.php
@@ -13,7 +13,7 @@
     <tr>
         <td class="column-60"><?= $this->e($column['title']) ?>
          <?php if (! empty($column['description'])): ?>
-            <span class="column-tooltip" title='<?= $this->markdown($column['description']) ?>'>
+            <span class="column-tooltip" title='<?= $this->e($this->markdown($column['description'])) ?>'>
                 <i class="fa fa-info-circle"></i>
             </span>
         <?php endif ?>

--- a/app/Template/board/swimlane.php
+++ b/app/Template/board/swimlane.php
@@ -28,7 +28,7 @@
         <?= $this->e($column['title']) ?>
 
         <?php if (! empty($column['description'])): ?>
-            <span class="column-tooltip pull-right" title='<?= $this->markdown($column['description']) ?>'>
+            <span class="column-tooltip pull-right" title='<?= $this->e($this->markdown($column['description'])) ?>'>
                 <i class="fa fa-info-circle"></i>
             </span>
         <?php endif ?>

--- a/app/Template/layout.php
+++ b/app/Template/layout.php
@@ -37,7 +37,7 @@
             <nav>
                 <h1><?= $this->a('K<span>B</span>', 'app', 'index', array(), false, 'logo', t('Dashboard')).' '.$this->summary($this->e($title)) ?>
                     <?php if (! empty($description)): ?>
-                        <span class="column-tooltip" title='<?= $this->markdown($description) ?>'>
+                        <span class="column-tooltip" title='<?= $this->e($this->markdown($description)) ?>'>
                             <i class="fa fa-info-circle"></i>
                         </span>
                     <?php endif ?>

--- a/app/Template/project/index.php
+++ b/app/Template/project/index.php
@@ -42,7 +42,7 @@
 
                         <?= $this->a($this->e($project['name']), 'project', 'show', array('project_id' => $project['id'])) ?>
                         <?php if (! empty($project['description'])): ?>
-                            <span class="column-tooltip" title='<?= $this->markdown($project['description']) ?>'>
+                            <span class="column-tooltip" title='<?= $this->e($this->markdown($project['description'])) ?>'>
                                 <i class="fa fa-info-circle"></i>
                             </span>
                         <?php endif ?>

--- a/app/Template/project/show.php
+++ b/app/Template/project/show.php
@@ -50,7 +50,7 @@
         <td>
             <?= $this->e($column['title']) ?>
             <?php if (! empty($column['description'])): ?>
-                <span class="column-tooltip" title='<?= $this->markdown($column['description']) ?>'>
+                <span class="column-tooltip" title='<?= $this->e($this->markdown($column['description'])) ?>'>
                     <i class="fa fa-info-circle"></i>
                 </span>
             <?php endif ?>


### PR DESCRIPTION
This is needed to avoid issues when the code contains quotes.