### PR TITLE
Add an action which logs the time a task has spent in a configured column

### DIFF
--- a/app/Action/TaskLogTimeSpent.php
+++ b/app/Action/TaskLogTimeSpent.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Action;
+
+use Model\Task;
+use Model\ProjectActivity;
+
+
+/**
+ * Logs the time a task spent in a specific column.
+ *
+ * @package action
+ * @author  Oren Ben-Kiki
+ */
+class TaskLogTimeSpent extends Base
+{
+    /**
+     * Get the list of compatible events
+     *
+     * @access public
+     * @return array
+     */
+    public function getCompatibleEvents()
+    {
+        return array(
+            Task::EVENT_MOVE_COLUMN,
+        );
+    }
+
+    /**
+     * Get the required parameter for the action (defined by the user)
+     *
+     * @access public
+     * @return array
+     */
+    public function getActionRequiredParameters()
+    {
+        return array('column_id' => t('Column'));
+    }
+
+    /**
+     * Get the required parameter for the event
+     *
+     * @access public
+     * @return string[]
+     */
+    public function getEventRequiredParameters()
+    {
+        return array('task_id', 'column_id');
+    }
+
+    /**
+     * Execute the action (Add the time in the column to the tasks time_spent).
+     *
+     * @access public
+     * @param  array   $data   Event data dictionary
+     * @return bool            True if the action was executed or false when not executed
+     */
+    public function doAction(array $data)
+    {
+        if (! $this->userSession->isLogged()) {
+            return false;
+        }
+        
+        $column = $this->board->getColumn($data['column_id']);
+
+        $task = $this->taskFinder->getById($data['task_id']);
+        $records = $this
+            ->db
+            ->table(ProjectActivity::TABLE)
+            ->eq('event_name',Task::EVENT_MOVE_COLUMN)
+            ->eq('project_id',$task['project_id'])
+            ->eq('task_id',$task['id'])
+            ->desc('date_creation')
+            ->limit(2)
+            ->findAllByColumn('date_creation');
+
+        $time_spent = $records[0] - $records[1];
+        $time_spent = ($time_spent / 60 / 60) + $task['time_spent'];
+
+        return (bool) $this
+            ->db
+            ->table(Task::TABLE)
+            ->eq('id',$task['id'])
+            ->update(['time_spent' => $time_spent]);
+    }
+
+    /**
+     * Check if the event data meet the action condition
+     *
+     * @access public
+     * @param  array   $data   Event data dictionary
+     * @return bool
+     */
+    public function hasRequiredCondition(array $data)
+    {
+        // only run the task if the task was moved out of the specified column
+        $retval = ($data['column_id'] != $this->getParam('column_id'));
+        if ($retval) {
+            // now check if the previus column was our action column
+            $task = $this->taskFinder->getById($data['task_id']);
+            $data = $this
+                ->db
+                ->table(ProjectActivity::TABLE)
+                ->eq('event_name',Task::EVENT_MOVE_COLUMN)
+                ->eq('project_id',$task['project_id'])
+                ->eq('task_id',$task['id'])
+                ->desc('date_creation')
+                ->limit(1)
+                ->offset(1)
+                ->findOneColumn('data');
+            $data = json_decode($data);
+            print_r($data);
+            $retval = ($data->task->column_id == $this->getParam('column_id'));
+        }
+        
+        return $retval;
+    }
+}

--- a/app/Action/TaskLogTimeSpent.php
+++ b/app/Action/TaskLogTimeSpent.php
@@ -110,7 +110,6 @@ class TaskLogTimeSpent extends Base
                 ->offset(1)
                 ->findOneColumn('data');
             $data = json_decode($data);
-            print_r($data);
             $retval = ($data->task->column_id == $this->getParam('column_id'));
         }
         

--- a/app/Model/Action.php
+++ b/app/Model/Action.php
@@ -53,6 +53,7 @@ class Action extends Base
             'TaskLogMoveAnotherColumn' => t('Add a comment logging moving the task between columns'),
             'TaskAssignUser' => t('Change the assignee based on an external username'),
             'TaskAssignCategoryLabel' => t('Change the category based on an external label'),
+            'TaskLogTimeSpent' => t('Logs the time a task spent in a specific column'),
         );
 
         asort($values);


### PR DESCRIPTION
This is useful, to track the time a task has spent in your work column.

I just duplicated the TaskLogMoveAnotherColumn task and adapted it to my needs. I'm not so deep into the hole code base, so I dont know if I could have fetched the project activities somewhat smarter or if thats ok.