### PR TITLE
Markdown escape option

### DIFF
--- a/app/Core/Helper.php
+++ b/app/Core/Helper.php
@@ -502,7 +502,7 @@ class Helper
     public function markdown($text, array $link = array())
     {
         $parser = new Markdown($link, $this);
-        $parser->setMarkupEscaped(MARKDOWN_ESCAPED);        
+        $parser->setMarkupEscaped(MARKDOWN_ESCAPED);
         return $parser->text($text);
     }
 

--- a/app/Core/Helper.php
+++ b/app/Core/Helper.php
@@ -502,7 +502,7 @@ class Helper
     public function markdown($text, array $link = array())
     {
         $parser = new Markdown($link, $this);
-        $parser->setMarkupEscaped(true);
+        $parser->setMarkupEscaped(MARKDOWN_ESCAPED);        
         return $parser->text($text);
     }
 

--- a/app/constants.php
+++ b/app/constants.php
@@ -74,3 +74,5 @@ defined('ENABLE_XFRAME') or define('ENABLE_XFRAME', true);
 // Default files directory
 defined('FILES_DIR') or define('FILES_DIR', 'data/files/');
 
+// Escape html inside markdown text
+define('MARKDOWN_ESCAPED', true);

--- a/config.default.php
+++ b/config.default.php
@@ -129,4 +129,4 @@ define('ENABLE_HSTS', true);
 define('ENABLE_XFRAME', true);
 
 // Escape html inside markdown text
-define('MARKDOWN_ESCAPED', false);
+define('MARKDOWN_ESCAPED', true);

--- a/config.default.php
+++ b/config.default.php
@@ -127,3 +127,6 @@ define('ENABLE_HSTS', true);
 
 // Enable or disable "X-Frame-Options: DENY" HTTP header
 define('ENABLE_XFRAME', true);
+
+// Escape html inside markdown text
+define('MARKDOWN_ESCAPED', false);


### PR DESCRIPTION
I was importing tasks from Jira to Kanboard and notice that inline html is escaped.
So I added option to tweak this behavour.