### PR TITLE
Fixed a bug where deletion of columns could break the 'Move up/down' column functionality

### DIFF
--- a/app/Model/Board.php
+++ b/app/Model/Board.php
@@ -158,7 +158,7 @@ class Board extends Base
         $columns = $this->db->hashtable(self::TABLE)->eq('project_id', $project_id)->asc('position')->getAll('id', 'position');
         $positions = array_flip($columns);
 
-        if (isset($columns[$column_id]) && $columns[$column_id] < count($columns)) {
+        if (isset($columns[$column_id]) && $columns[$column_id] < max($columns)) {
             // Increase the position, for as long as we don't find another column
             do {
                 $position = ++$columns[$column_id];
@@ -190,7 +190,7 @@ class Board extends Base
         $columns = $this->db->hashtable(self::TABLE)->eq('project_id', $project_id)->asc('position')->getAll('id', 'position');
         $positions = array_flip($columns);
 
-        if (isset($columns[$column_id]) && $columns[$column_id] > 1) {
+        if (isset($columns[$column_id]) && $columns[$column_id] > min($columns)) {
             // Decrease the position, for as long as we don't find another column
             do {
                 $position = --$columns[$column_id];

--- a/app/Model/Board.php
+++ b/app/Model/Board.php
@@ -159,8 +159,11 @@ class Board extends Base
         $positions = array_flip($columns);
 
         if (isset($columns[$column_id]) && $columns[$column_id] < count($columns)) {
+            // Increase the position, for as long as we don't find another column
+            do {
+                $position = ++$columns[$column_id];
+            } while(!isset($positions[$position]));
 
-            $position = ++$columns[$column_id];
             $columns[$positions[$position]]--;
 
             $this->db->startTransaction();
@@ -188,8 +191,11 @@ class Board extends Base
         $positions = array_flip($columns);
 
         if (isset($columns[$column_id]) && $columns[$column_id] > 1) {
+            // Decrease the position, for as long as we don't find another column
+            do {
+                $position = --$columns[$column_id];
+            } while(!isset($positions[$position]));
 
-            $position = --$columns[$column_id];
             $columns[$positions[$position]]++;
 
             $this->db->startTransaction();

--- a/app/Template/column/index.php
+++ b/app/Template/column/index.php
@@ -24,12 +24,12 @@
                 <li>
                     <?= $this->a(t('Edit'), 'column', 'edit', array('project_id' => $project['id'], 'column_id' => $column['id'])) ?>
                 </li>
-                <?php if ($column['position'] != 1): ?>
+                <?php if ($column !== reset($columns)): ?>
                 <li>
                     <?= $this->a(t('Move Up'), 'column', 'move', array('project_id' => $project['id'], 'column_id' => $column['id'], 'direction' => 'up'), true) ?>
                 </li>
                 <?php endif ?>
-                <?php if ($column['position'] != count($columns)): ?>
+                <?php if ($column['position'] !== end($columns)): ?>
                 <li>
                     <?= $this->a(t('Move Down'), 'column', 'move', array('project_id' => $project['id'], 'column_id' => $column['id'], 'direction' => 'down'), true) ?>
                 </li>


### PR DESCRIPTION
Hi,

We recently encountered a bug that we couldn't move a column upwards in one of our boards. After some researching it seems that when a column is removed, the sort order gets messed up. Instead of getting a list of position 1, 2, 3, the order can be (ex;) 1, 2, 4 after deleting. 

When moving the item on the fourth position up, a PHP notice UNDEFINED INDEX occurs, because the position to move to is not taken anymore (it's removed, since the column was removed).

This fix ensures that the position is changed with a valid row. It loops through the positions until a valid position is found.

The safeguards for calling the moveUp/moveDown columns have also been changed appropriately, as well as the template where the 'Move up' / 'Move down' actions are shown.
