### PR TITLE
php5-gd added to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Frederic Guillot <fred@kanboard.net>
 RUN apt-get update && apt-get install -y apache2 php5 php5-gd php5-sqlite git curl && apt-get clean
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 RUN curl -sS https://getcomposer.org/installer | php -- --filename=/usr/local/bin/composer
-RUN cd /var/www && git clone https://github.com/lefakir/kanboard.git
+RUN cd /var/www && git clone https://github.com/fguillot/kanboard.git
 RUN cd /var/www/kanboard && composer install
 RUN rm -rf /var/www/html && mv /var/www/kanboard /var/www/html
 RUN chown -R www-data:www-data /var/www/html/data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:14.04
 MAINTAINER Frederic Guillot <fred@kanboard.net>
 
-RUN apt-get update && apt-get install -y apache2 php5 php5-sqlite git curl && apt-get clean
+RUN apt-get update && apt-get install -y apache2 php5 php5-gd php5-sqlite git curl && apt-get clean
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 RUN curl -sS https://getcomposer.org/installer | php -- --filename=/usr/local/bin/composer
-RUN cd /var/www && git clone https://github.com/fguillot/kanboard.git
+RUN cd /var/www && git clone https://github.com/lefakir/kanboard.git
 RUN cd /var/www/kanboard && composer install
 RUN rm -rf /var/www/html && mv /var/www/kanboard /var/www/html
 RUN chown -R www-data:www-data /var/www/html/data


### PR DESCRIPTION
Hi, I had an issue while deploying Kanboard on a DigitalOcean VPS :
Composer failed tu use ext-gd.

So i tried to add explicitely the php5-gd package and it worked.