### PR TITLE
Correct LocaleUnitTest to actually check the number of %d placeholder…

### DIFF
--- a/tests/units/LocaleTest.php
+++ b/tests/units/LocaleTest.php
@@ -22,8 +22,8 @@ class LocaleTest extends Base
 
                 foreach(array('%s', '%d') as $placeholder) {
                     $this->assertEquals(
-                        substr_count($k, '%s'),
-                        substr_count($v, '%s'),
+                        substr_count($k, $placeholder),
+                        substr_count($v, $placeholder),
                         'Incorrect number of ' . $placeholder . ' in ' . basename($file) .' translation of: ' . $k
                     );
                 }


### PR DESCRIPTION
…s are correct.

Apologies, there was a bug in the commit I made yesterday which meant that only the %s placeholders were being checked (twice).  This pull request resolves that issue.