### PR TITLE
Slack channel can be overridden to post to another channel/private group or send direct messages

### DIFF
--- a/app/Integration/SlackWebhook.php
+++ b/app/Integration/SlackWebhook.php
@@ -38,6 +38,23 @@ class SlackWebhook extends \Core\Base
         $options = $this->projectIntegration->getParameters($project_id);
         return $options['slack_webhook_url'];
     }
+    
+    /**
+     * Get optional Slack channel
+     *
+     * @access public
+     * @param  integer  $project_id
+     * @return string
+     */
+    public function getChannel($project_id)
+    {
+    	if (!empty($this->config->get('integration_slack_webhook_channel'))) {
+    		return $this->config->get('integration_slack_webhook_channel');
+    	}
+    
+    	$options = $this->projectIntegration->getParameters($project_id);
+    	return $options['slack_webhook_channel'];
+    }
 
     /**
      * Send message to the incoming Slack webhook
@@ -67,6 +84,11 @@ class SlackWebhook extends \Core\Base
                 $payload['text'] .= ' - <'.$this->config->get('application_url');
                 $payload['text'] .= $this->helper->url->href('task', 'show', array('task_id' => $task_id, 'project_id' => $project_id));
                 $payload['text'] .= '|'.t('view the task on Kanboard').'>';
+            }
+            
+            $channel = $this->getChannel($project_id);
+            if (!empty($channel)) {
+            	$payload['channel'] = $channel;
             }
 
             $this->httpClient->postJson($this->getWebhookUrl($project_id), $payload);

--- a/app/Template/config/integrations.php
+++ b/app/Template/config/integrations.php
@@ -77,6 +77,8 @@
 
         <?= $this->form->label(t('Webhook URL'), 'integration_slack_webhook_url') ?>
         <?= $this->form->text('integration_slack_webhook_url', $values, $errors) ?>
+        <?= $this->form->label(t('Channel/Group/User (Optional)'), 'integration_slack_webhook_channel') ?>
+        <?= $this->form->text('integration_slack_webhook_channel', $values, $errors) ?>
 
         <p class="form-help"><a href="http://kanboard.net/documentation/slack" target="_blank"><?= t('Help on Slack integration') ?></a></p>
     </div>

--- a/app/Template/project/integrations.php
+++ b/app/Template/project/integrations.php
@@ -85,6 +85,8 @@
 
         <?= $this->form->label(t('Webhook URL'), 'slack_webhook_url') ?>
         <?= $this->form->text('slack_webhook_url', $values, $errors) ?>
+        <?= $this->form->label(t('Channel/Group/User (Optional)'), 'slack_webhook_channel') ?>
+        <?= $this->form->text('slack_webhook_channel', $values, $errors) ?>
 
         <p class="form-help"><a href="http://kanboard.net/documentation/slack" target="_blank"><?= t('Help on Slack integration') ?></a></p>
 

--- a/docs/slack.markdown
+++ b/docs/slack.markdown
@@ -26,3 +26,14 @@ This feature use the [Incoming webhook](https://api.slack.com/incoming-webhooks)
 3. Copy the webhook url to the Kanboard settings page: **Settings > Integrations > Slack** or **Project settings > Integrations > Slack**
 
 Now, Kanboard events will be sent to the Slack channel.
+
+### Overriding Channel (Optional)
+
+Optnally you can override the channel, private group or send direct messages by filling up **Channel/Group/User** textbox. Leaving it empty will post to the channel configured during webhook configuration.
+
+Examples:
+
+- #mychannel1 - Send message to channel 'mychannel1'
+- #myprivategroup1 - Send message to private group 'myprivategroup1' 
+- @anotheruser1 - Send message to user 'anotheruser1'
+


### PR DESCRIPTION
A small patch since Slack supports overriding channel configured during creation of webhook. 

Need to execute these SQLs to make changes in database. I deliberately didn't include them in database files to avoid conflicts. 

```
INSERT INTO settings VALUES ('integration_slack_webhook_channel', '');

ALTER TABLE project_integrations ADD COLUMN slack_webhook_channel text;
```
This helps when you just want to reuse a single webhook in Slack. We use Gitlab and use a single webhook and override in each project to post to different channels instead of creating multiple hooks.

