### PR TITLE
Enable nonAdmins to change private projekts to normal

### DIFF
--- a/app/Controller/Project.php
+++ b/app/Controller/Project.php
@@ -140,7 +140,7 @@ class Project extends Base
         $project = $this->getProject();
         $values = $this->request->getValues();
 
-        if ($project['is_private'] == 1 && $this->userSession->isAdmin() && ! isset($values['is_private'])) {
+        if ($project['is_private'] == 1 && ! isset($values['is_private'])) {
             $values += array('is_private' => 0);
         }
 

--- a/app/Template/project/edit.php
+++ b/app/Template/project/edit.php
@@ -13,7 +13,7 @@
     <?= $this->form->text('identifier', $values, $errors, array('maxlength="50"')) ?>
     <p class="form-help"><?= t('The project identifier is an optional alphanumeric code used to identify your project.') ?></p>
 
-    <?php if ($this->user->isAdmin()): ?>
+    <?php if ($this->user->isAdmin() || $this->user->isManager($project['id'])): ?>
         <?= $this->form->checkbox('is_private', t('Private project'), 1, $project['is_private'] == 1) ?>
     <?php endif ?>
 


### PR DESCRIPTION
- isAdmin function must be disabled to enable a manager to convert private projects to normal projects.
- Edit.php code is updated with isManager to enable Managers to update private projects to normal projects by editing in the project edit formular.