### PR TITLE
Require autoloader relative from the current directory

### DIFF
--- a/app/common.php
+++ b/app/common.php
@@ -1,6 +1,6 @@
 <?php
 
-require 'vendor/autoload.php';
+require dirname(__DIR__) . '/vendor/autoload.php';
 
 // Automatically parse environment configuration (Heroku)
 if (getenv('DATABASE_URL')) {


### PR DESCRIPTION
Require autoloader relative from the current directory, otherwise I get the following messages:

    PHP Warning:  require(vendor/autoload.php): failed to open stream: No such file or directory in /var/www/virtual/user/kanboard-1.0.16/app/common.php on line 3
    PHP Fatal error:  require(): Failed opening required 'vendor/autoload.php' (include_path='.:/package/host/localhost/php-5.6.10/lib/php') in /var/www/virtual/user/kanboard-1.0.16/app/common.php on line 3