### PR TITLE
Changed NL translation of 'Remaining'

### DIFF
--- a/app/Locale/nl_NL/translations.php
+++ b/app/Locale/nl_NL/translations.php
@@ -313,7 +313,7 @@ return array(
     'Estimate:' => 'Schatting :',
     'Spent:' => 'Besteed :',
     'Do you really want to remove this sub-task?' => 'Weet u zeker dat u deze subtaak wil verwijderen ?',
-    'Remaining:' => 'Restant :',
+    'Remaining:' => 'Resterend :',
     'hours' => 'uren',
     'spent' => 'besteed',
     'estimated' => 'geschat',


### PR DESCRIPTION
I personally think Resterend fits in better then Restant because its fits better in the sentence. Please let me know if you prefer a different approach.