### PR TITLE
Fixes the javascript issue on swimlane board 

### DIFF
--- a/assets/js/src/Popover.js
+++ b/assets/js/src/Popover.js
@@ -15,7 +15,6 @@ Popover.prototype.open = function(link) {
     $.get(link, function(content) {
         $("body").append('<div id="popover-container"><div id="popover-content">' + content + '</div></div>');
         self.router.dispatch();
-        self.app.refresh();
         self.afterOpen();
     });
 };


### PR DESCRIPTION
Since you already have handlers registered on the page you don't need to remove them and then add them again when popover opens up