### PR TITLE
Add filter by task link

### DIFF
--- a/app/Core/Lexer.php
+++ b/app/Core/Lexer.php
@@ -39,6 +39,7 @@ class Lexer
         "/^(swimlane:)/"                                 => 'T_SWIMLANE',
         "/^(ref:)/"                                      => 'T_REFERENCE',
         "/^(reference:)/"                                => 'T_REFERENCE',
+        "/^(link:)/"                                     => 'T_LINK',
         "/^(\s+)/"                                       => 'T_WHITESPACE',
         '/^([<=>]{0,2}[0-9]{4}-[0-9]{2}-[0-9]{2})/'      => 'T_DATE',
         '/^(yesterday|tomorrow|today)/'                  => 'T_DATE',
@@ -118,6 +119,7 @@ class Lexer
                 case 'T_COLUMN':
                 case 'T_PROJECT':
                 case 'T_SWIMLANE':
+                case 'T_LINK':
                     $next = next($tokens);
 
                     if ($next !== false && $next['token'] === 'T_STRING') {

--- a/app/Model/TaskFilter.php
+++ b/app/Model/TaskFilter.php
@@ -30,6 +30,7 @@ class TaskFilter extends Base
         'T_COLUMN' => 'filterByColumnName',
         'T_REFERENCE' => 'filterByReference',
         'T_SWIMLANE' => 'filterBySwimlaneName',
+        'T_LINK' => 'filterByLinkName',
     );
 
     /**
@@ -105,6 +106,22 @@ class TaskFilter extends Base
             )
             ->join(User::TABLE, 'id', 'user_id', Subtask::TABLE)
             ->neq(Subtask::TABLE.'.status', Subtask::STATUS_DONE);
+    }
+
+    /**
+     * Create a new link query
+     *
+     * @access public
+     * @return \PicoDb\Table
+     */
+    public function createLinkQuery()
+    {
+        return $this->db->table(TaskLink::TABLE)
+            ->columns(
+                TaskLink::TABLE.'.task_id',
+                Link::TABLE.'.label'
+            )
+            ->join(Link::TABLE, 'id', 'link_id', TaskLink::TABLE);
     }
 
     /**
@@ -502,6 +519,30 @@ class TaskFilter extends Base
         if ($is_active >= 0) {
             $this->query->eq(Task::TABLE.'.is_active', $is_active);
         }
+
+        return $this;
+    }
+
+    /**
+     * Filter by link
+     *
+     * @access public
+     * @param  array    $values   List of links
+     * @return TaskFilter
+     */
+    public function filterByLinkName(array $values)
+    {
+        $this->query->beginOr();
+
+        $link_query = $this->createLinkQuery()->in(Link::TABLE.'.label', $values);
+        $matching_task_ids = $link_query->findAllByColumn('task_id');
+        if (empty($matching_task_ids)) {
+            $this->query->eq(Task::TABLE.'.id', 0);
+        } else {
+            $this->query->in(Task::TABLE.'.id', $matching_task_ids);
+        }
+
+        $this->query->closeOr();
 
         return $this;
     }

--- a/doc/search.markdown
+++ b/doc/search.markdown
@@ -136,3 +136,11 @@ Attribute: **swimlane**
 - Find tasks in the default swimlane: `swimlane:default`
 - Find tasks into several swimlanes: `swimlane:"Version 1.2" swimlane:"Version 1.3"`
 
+Search by task link
+------------------
+
+Attribute: **link**
+
+- Find tasks by link name: `link:"is a milestone of"`
+- Find tasks into several links: `link:"is a milestone of" link:"relates to"`
+

--- a/tests/units/Core/LexerTest.php
+++ b/tests/units/Core/LexerTest.php
@@ -116,6 +116,31 @@ class LexerTest extends Base
         );
     }
 
+    public function testLinkQuery()
+    {
+        $lexer = new Lexer;
+    
+        $this->assertEquals(
+            array(array('match' => 'link:', 'token' => 'T_LINK'), array('match' => 'is a milestone of', 'token' => 'T_STRING')),
+            $lexer->tokenize('link:"is a milestone of"')
+            );
+
+        $this->assertEquals(
+            array('T_LINK' => array('is a milestone of')),
+            $lexer->map($lexer->tokenize('link:"is a milestone of"'))
+            );
+
+        $this->assertEquals(
+            array('T_LINK' => array('is a milestone of', 'fixes')),
+            $lexer->map($lexer->tokenize('link:"is a milestone of" link:fixes'))
+            );
+
+        $this->assertEquals(
+            array(),
+            $lexer->map($lexer->tokenize('link: '))
+            );
+    }
+
     public function testColumnQuery()
     {
         $lexer = new Lexer;


### PR DESCRIPTION
This PR add the possibility to filter tasks using task links. For example: status:open link:"is a milestone of".

I have added a TaskFilter::filterByLinkName method and used a similar logic as TaskFilter:filterBySubtaskAssignee. I have also updated english documentation and unit tests.

I did not understand the point of creating a TaskFilter::filterByLink method, (I did not find where TaskFilter::filterByColor, TaskFilter::filterByCategory, ... are used), so I did not create it yet. Please ask me if required.