### PR TITLE
Get informations from ldap directory even if we use SSO

### DIFF
--- a/app/Auth/ReverseProxy.php
+++ b/app/Auth/ReverseProxy.php
@@ -66,7 +66,7 @@ class ReverseProxy extends Ldap
      */
     private function createUser($login)
     {
-        if (LDAP_ACCOUNT_CREATION ) {
+        if (LDAP_ACCOUNT_CREATION && is_array($this->lookup($login)) ) {
             $result=$this->lookup($login);
         }
         else {

--- a/app/Auth/ReverseProxy.php
+++ b/app/Auth/ReverseProxy.php
@@ -66,22 +66,21 @@ class ReverseProxy extends Ldap
      */
     private function createUser($login)
     {
-        $email = strpos($login, '@') !== false ? $login : '';
-
-        if (REVERSE_PROXY_DEFAULT_DOMAIN !== '' && empty($email)) {
-            $email = $login.'@'.REVERSE_PROXY_DEFAULT_DOMAIN;
-        }
-        $result=array(
-            'email' => $email,
-            'username' => $login,
-            'is_admin' => REVERSE_PROXY_DEFAULT_ADMIN === $login,
-            'is_ldap_user' => 1,
-            'disable_login_form' => 1,
-        );
         if (LDAP_ACCOUNT_CREATION ) {
             $result=$this->lookup($login);
-            $result[ 'is_admin']=0;
-            $result[ 'is_ldap_user']=1;
+        }
+        else {
+            $email = strpos($login, '@') !== false ? $login : '';
+            if (REVERSE_PROXY_DEFAULT_DOMAIN !== '' && empty($email)) {
+                $email = $login.'@'.REVERSE_PROXY_DEFAULT_DOMAIN;
+            }
+            $result=array(
+                'email' => $email,
+                'username' => $login,
+                'is_admin' => REVERSE_PROXY_DEFAULT_ADMIN === $login,
+                'is_ldap_user' => 1,
+                'disable_login_form' => 1,
+                );
         }
         return $this->user->create($result);
     }

--- a/app/Auth/ReverseProxy.php
+++ b/app/Auth/ReverseProxy.php
@@ -11,7 +11,7 @@ use Kanboard\Event\AuthEvent;
  * @package  auth
  * @author   Sylvain Veyrié
  */
-class ReverseProxy extends Base
+class ReverseProxy extends Ldap
 {
     /**
      * Backend name
@@ -71,13 +71,18 @@ class ReverseProxy extends Base
         if (REVERSE_PROXY_DEFAULT_DOMAIN !== '' && empty($email)) {
             $email = $login.'@'.REVERSE_PROXY_DEFAULT_DOMAIN;
         }
-
-        return $this->user->create(array(
+        $result=array(
             'email' => $email,
             'username' => $login,
             'is_admin' => REVERSE_PROXY_DEFAULT_ADMIN === $login,
             'is_ldap_user' => 1,
             'disable_login_form' => 1,
-        ));
+        );
+        if (LDAP_ACCOUNT_CREATION ) {
+            $result=$this->lookup($login);
+            $result[ 'is_admin']=0;
+            $result[ 'is_ldap_user']=1;
+        }
+        return $this->user->create($result);
     }
 }


### PR DESCRIPTION
If we enable SSO and Ldap in config.php, the first time a user ID is passed by the reverse proxy to Kanboard, informations about this user are bringing from the directory.