### PR TITLE
Add reference to the createComment parameters

### DIFF
--- a/app/Api/Comment.php
+++ b/app/Api/Comment.php
@@ -25,12 +25,13 @@ class Comment extends \Kanboard\Core\Base
         return $this->comment->remove($comment_id);
     }
 
-    public function createComment($task_id, $user_id, $content)
+    public function createComment($task_id, $user_id, $content, $reference = '')
     {
         $values = array(
             'task_id' => $task_id,
             'user_id' => $user_id,
             'comment' => $content,
+            'reference' => $reference,
         );
 
         list($valid, ) = $this->comment->validateCreation($values);


### PR DESCRIPTION
I've only seen the reference column being used by integrations (gitbucket,etc), would be nice that from the API we could also use that column for other references.