### PR TITLE
Adding php5-ldap to Dockerfile installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 MAINTAINER Frederic Guillot <fred@kanboard.net>
 
-RUN apt-get update && apt-get install -y apache2 php5 php5-gd php5-sqlite git curl && apt-get clean
+RUN apt-get update && apt-get install -y apache2 php5 php5-gd php5-ldap php5-sqlite git curl && apt-get clean
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf && a2enmod rewrite
 RUN sed -ri 's/AllowOverride None/AllowOverride All/g' /etc/apache2/apache2.conf
 RUN curl -sS https://getcomposer.org/installer | php -- --filename=/usr/local/bin/composer


### PR DESCRIPTION
I'm suggesting to add "php5-ldap" docker the Dockerfile installation list. If not done, ldap_auth won't work using a config.php file.