### PR TITLE
Move default-src CSP rule to ClassProvider

### DIFF
--- a/app/Core/Http/Response.php
+++ b/app/Core/Http/Response.php
@@ -220,7 +220,6 @@ class Response extends Base
      */
     public function csp(array $policies = array())
     {
-        $policies['default-src'] = "'self'";
         $values = '';
 
         foreach ($policies as $policy => $acl) {

--- a/app/ServiceProvider/ClassProvider.php
+++ b/app/ServiceProvider/ClassProvider.php
@@ -167,7 +167,10 @@ class ClassProvider implements ServiceProviderInterface
             return $mailer;
         };
 
-        $container['cspRules'] = array('style-src' => "'self' 'unsafe-inline'", 'img-src' => '* data:');
+        $container['cspRules'] = array(
+            'style-src' => "'self' 'unsafe-inline'",
+            'img-src' => '* data:',
+        );
 
         return $container;
     }

--- a/app/ServiceProvider/ClassProvider.php
+++ b/app/ServiceProvider/ClassProvider.php
@@ -168,6 +168,7 @@ class ClassProvider implements ServiceProviderInterface
         };
 
         $container['cspRules'] = array(
+            'default-src' => "'self'",
             'style-src' => "'self' 'unsafe-inline'",
             'img-src' => '* data:',
         );


### PR DESCRIPTION
It was impossible to override the default-src CSP rule inside a plugin. This patch fixes this limitation by moving the assignation of the rule from Response class to ClassProvider.