### PR TITLE
Create an account without password and send an email to the new user

### DIFF
--- a/app/Locale/fr_FR/translations.php
+++ b/app/Locale/fr_FR/translations.php
@@ -1121,4 +1121,13 @@ return array(
     'Highest priority' => 'Priorité haute',
     'If you put zero to the low and high priority, this feature will be disabled.' => 'Si vous mettez zéro pour la priorité basse et haute, cette fonctionnalité sera désactivée.',
     'Priority: %d' => 'Priorité : %d',
+    'Or send an invitation by email' => 'Ou envoyer une invitation par email',
+    'If you check the box "Send an invitation by email", "Password" is discarded and an email is sent to the new user to let him choose its own. In this case "Email" is required.' => 'Si vous cochez la case « Envoyer une invitation par email », « Mot de passe » est alors ignoré et un email est envoyé au nouvel utilisateur pour qu\'il en sélectionne un lui-même. Dans ce cas, « Email » est obligatoire.',
+    'The email is required to send the invitation' => 'L\'email est nécessaire pour pouvoir envoyer une invitation',
+    'An invitation has been sent by email.' => 'Une invitation a été envoyée par email.',
+    'New account for Kanboard' => 'Nouveau compte Kanboard',
+    'Welcome to Kanboard %s' => 'Bienvenue sur Kanboard %s',
+    'An account has been created for you on Kanboard by "%s".' => 'Un compte a été créé pour vous sur Kanboard par "%s".',
+    'Your login is "%s".' => 'Votre login est "%s".',
+    'Choose your password by clicking on this link: %s' => 'Choisissez votre mot de passe en cliquant sur ce lien : %s',
 );

--- a/app/Template/user/create_local.php
+++ b/app/Template/user/create_local.php
@@ -20,11 +20,15 @@
             <?= $this->form->label(t('Email'), 'email') ?>
             <?= $this->form->email('email', $values, $errors) ?>
 
+            <br /><br /><hr />
             <?= $this->form->label(t('Password'), 'password') ?>
-            <?= $this->form->password('password', $values, $errors, array('required')) ?>
+            <?= $this->form->password('password', $values, $errors) ?>
 
             <?= $this->form->label(t('Confirmation'), 'confirmation') ?>
-            <?= $this->form->password('confirmation', $values, $errors, array('required')) ?>
+            <?= $this->form->password('confirmation', $values, $errors) ?>
+
+            <?= $this->form->checkbox('email_invitation', t('Or send an invitation by email'), 1, isset($values['email_invitation']) && $values['email_invitation'] == 1 ? true : false) ?>
+            <hr />
         </div>
 
         <div class="form-column">
@@ -49,5 +53,10 @@
             <?= $this->url->link(t('cancel'), 'user', 'index') ?>
         </div>
     </form>
+    <div class="alert alert-info">
+        <ul>
+            <li><?= t('If you check the box "Send an invitation by email", "Password" is discarded and an email is sent to the new user to let him choose its own. In this case "Email" is required.') ?></li>
+        </ul>
+    </div>
     </section>
 </section>

--- a/app/Template/user/email_invitation.php
+++ b/app/Template/user/email_invitation.php
@@ -1,0 +1,9 @@
+<p><strong><?= t('Welcome to Kanboard %s', $user['name'] ?: $user['username']) ?></strong></p>
+
+<p><?= t('An account has been created for you on Kanboard by "%s".', $invitor['name'] ?: $invitor['username']) ?></p>
+
+<p><?= t('Your login is "%s".', $user['username']) ?></p>
+<p><?= t('Choose your password by clicking on this link: %s', $this->url->to('PasswordReset', 'change', array('token' => $token), '', true)) ?></p>
+
+<hr>
+Kanboard

--- a/app/Validator/UserValidator.php
+++ b/app/Validator/UserValidator.php
@@ -46,6 +46,10 @@ class UserValidator extends Base
 
         if (isset($values['is_ldap_user']) && $values['is_ldap_user'] == 1) {
             $v = new Validator($values, array_merge($rules, $this->commonValidationRules()));
+        } else if (isset($values['email_invitation']) && $values['email_invitation'] == 1) {
+            $v = new Validator($values, array_merge($rules, $this->commonValidationRules(), array(
+                new Validators\Required('email', t('The email is required to send the invitation')),
+            )));
         } else {
             $v = new Validator($values, array_merge($rules, $this->commonValidationRules(), $this->commonPasswordValidationRules()));
         }


### PR DESCRIPTION
This PR adds a new check-box in the "Create local user" form. If checked, an email is sent to the new user with a link to select a password (using the reset password mechanism). In this case, "password" fields became optionals (a random password of 12 characters is generated for the new user to prevent anyone to access the account before the real user) and "email" field became mandatory. 

This is useful for an administrator to create new user and invite them to join Kanboard. Before that, the administrator had to choose a password and to send it by email or post-it to the finale user.

If accepted, I have few enhancements in mind for the future:
* The import mechanism should also send an email to the new users when no password nor remote id is provided. But I don't know yet how to avoid code duplication for this use case...
* Add a "Application name" that will be displayed in the email instead of just "Kanboard" (e.g. "Kanboard CompanyG")
* Add a "state" (or similar) to the password reset mechanism in order to spot if it is an "invitation" or a "password reset request". This will allow to display a "Welcome" page to the new user instead of a "Password Reset" page.
* Does it make sense to do the same for remote user? To invite them to login with their Google or Github or ... account.
* Add a "Reset Password" button for administrator in a "Edit password" view of a user

All comments are welcome.