### PR TITLE
Remove duplicate ext-hash in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "ext-hash" : "*",
         "ext-openssl" : "*",
         "ext-json" : "*",
-        "ext-hash" : "*",
         "ext-ctype" : "*",
         "ext-filter" : "*",
         "ext-session" : "*",


### PR DESCRIPTION
There were two `ext-hash` in `composer.json`