### PR TITLE
template hook for css media = print

### DIFF
--- a/app/Helper/Asset.php
+++ b/app/Helper/Asset.php
@@ -35,6 +35,19 @@ class Asset extends \Kanboard\Core\Base
     }
 
     /**
+     * Add a stylesheet asset media = print
+     *
+     * @param  string   $filename   Filename
+     * @param  boolean  $is_file    Add file timestamp
+     * @param  string   $media      Media
+     * @return string
+     */
+    public function css_print($filename, $is_file = true, $media = 'print')
+    {
+        return '<link rel="stylesheet" href="'.$this->helper->url->dir().$filename.($is_file ? '?'.filemtime($filename) : '').'" media="'.$media.'">';
+    }
+
+    /**
      * Get custom css
      *
      * @access public

--- a/app/Template/layout.php
+++ b/app/Template/layout.php
@@ -22,6 +22,7 @@
         <?= $this->asset->customCss() ?>
 
         <?= $this->hook->asset('css', 'template:layout:css') ?>
+        <?= $this->hook->asset('css_print', 'template:layout:css_print') ?>
         <?= $this->hook->asset('js', 'template:layout:js') ?>
 
         <link rel="icon" type="image/png" href="<?= $this->url->dir() ?>assets/img/favicon.png">

--- a/doc/plugin-hooks.markdown
+++ b/doc/plugin-hooks.markdown
@@ -121,7 +121,8 @@ class Plugin extends Base
 
 List of asset Hooks:
 
-- `template:layout:css`
+- `template:layout:css` media='screen'
+- `templare:layout:css_print` media='print'
 - `template:layout:js`
 
 Template Hooks


### PR DESCRIPTION
I added a new hook in Template/layout (templare:layout:css_print) which calls the new function Helper->Asset->css_print. This function inserts a given css file as media='print'.

I also updated the documentation.

Related to https://github.com/fguillot/kanboard/issues/1864