### PR TITLE
compatibility for disabling user select

### DIFF
--- a/assets/css/src/board.css
+++ b/assets/css/src/board.css
@@ -138,6 +138,8 @@ a.board-swimlane-toggle:focus {
 .draggable-item {
     cursor: pointer;
     user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
 }
 
 .draggable-placeholder {


### PR DESCRIPTION
I'm using Chrome & the CSS rule disabling user-select wasn't working for me.  I was occasionally selecting the text on a board task rather than dragging it.

These two rules should help for different browser versions.