### PR TITLE
Changing new self to new static, to accommodate subclasses

### DIFF
--- a/app/Core/Ldap/Client.php
+++ b/app/Core/Ldap/Client.php
@@ -31,7 +31,7 @@ class Client
      */
     public static function connect($username = null, $password = null)
     {
-        $client = new self;
+        $client = new static;
         $client->open($client->getLdapServer());
         $username = $username ?: $client->getLdapUsername();
         $password = $password ?: $client->getLdapPassword();


### PR DESCRIPTION
I created a subclass of Kanboard\Core\Ldap\Client, which overrides a handful of methods.  Using new static, instead of new self ensures that the new instance will be of the calling class, instead of Kanboard\Core\LDAP\Client.