### PR TITLE
Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  kanboard:
+    image: kanboard/kanboard:stable
+    ports:
+     - "80:80"
+    volumes:
+     - kanboard_data:/var/www/kanboard/data
+     - kanboard_plugins:/var/www/kanboard/plugins
+volumes:
+  kanboard_data:
+    driver: local
+  kanboard_plugins:
+    driver: local


### PR DESCRIPTION
Simple docker-compose file.
Instead of using the image from the repository it could instead build the local `Dockerfile`.

This was useful to me, maybe it can be useful to someone else too.