### PR TITLE
Loader for Helper-Classes from Plugin

### DIFF
--- a/app/Core/Plugin/Base.php
+++ b/app/Core/Plugin/Base.php
@@ -41,6 +41,17 @@ abstract class Base extends \Kanboard\Core\Base
     }
 
     /**
+     * Returns all helper classes that needs to be stored in the DI container
+     *
+     * @access public
+     * @return array
+     */
+    public function getHelpers()
+    {
+        return array();
+    }
+
+    /**
      * Listen on internal events
      *
      * @access public

--- a/app/Core/Plugin/Loader.php
+++ b/app/Core/Plugin/Loader.php
@@ -70,6 +70,8 @@ class Loader extends \Kanboard\Core\Base
 
         Tool::buildDic($this->container, $instance->getClasses());
 
+        Tool::buildDICHelpers($this->container, $instance->getHelpers());
+
         $instance->initialize();
         $this->plugins[] = $instance;
     }

--- a/app/Core/Tool.php
+++ b/app/Core/Tool.php
@@ -56,6 +56,27 @@ class Tool
     }
 
     /**
+     * Build dependency injection container for custom helpers from an array
+     *
+     * @static
+     * @access public
+     * @param  Container  $container
+     * @param  array      $namespaces
+     * @return Container
+     */
+    public static function buildDICHelpers(Container $container, array $namespaces)
+    {
+        foreach ($namespaces as $namespace => $classes) {
+            foreach ($classes as $name) {
+                $class = '\\Kanboard\\'.$namespace.'\\'.$name;
+                $container['helper']->register($name, $class);
+            }
+        }
+
+        return $container;
+    }
+
+    /**
      * Generate a jpeg thumbnail from an image
      *
      * @static


### PR DESCRIPTION
This PR adds a new function for loading own helper classes which then will be available directly in templates.

From within the Plugin.php you have to declare the function getHelpers:

```
public function getHelpers()
{
    return array(
        'Plugin\MyPlugin\MyFolder' => array(
                'MyHelperClass'
        )
    );
}
```

In the template you can call your helper-class:

`<?php $this->MyHelperClass->MyPrettyFunction(); ?>`

I hope, this is helpful :smile: 

@fguillot 
If you think, it's OK this way, I will also update the doku.