### PR TITLE
Flashing an error if a nonexistent user is added to a project.

### DIFF
--- a/app/Controller/ProjectPermission.php
+++ b/app/Controller/ProjectPermission.php
@@ -83,7 +83,9 @@ class ProjectPermission extends Base
         $project = $this->getProject();
         $values = $this->request->getValues();
 
-        if ($this->projectUserRole->addUser($values['project_id'], $values['user_id'], $values['role'])) {
+        if (empty($values['user_id'])) {
+            $this->flash->failure(t('User not found.'));
+        } elseif ($this->projectUserRole->addUser($values['project_id'], $values['user_id'], $values['role'])) {
             $this->flash->success(t('Project updated successfully.'));
         } else {
             $this->flash->failure(t('Unable to update this project.'));


### PR DESCRIPTION
Currently, if you go into project permissions, and type the name of a user that doesn't exist and press enter, the form will submit, and you'll get a SQL error.  This fix flashes an error instead.