### PR TITLE
Add missing translatable string

### DIFF
--- a/app/Locale/fr_FR/translations.php
+++ b/app/Locale/fr_FR/translations.php
@@ -1163,4 +1163,8 @@ return array(
     'Search by task status: ' => 'Rechercher par le statut des tâches : ',
     'Search by task title: ' => 'Rechercher par le titre des tâches : ',
     'Activity stream search' => 'Recherche dans le flux d\'activité',
+    'Projects where "%s" is manager' => '',
+    'Projects where "%s" is member' => '',
+    'Open tasks assigned to "%s"' => '',
+    'Closed tasks assigned to "%s"' => '',
 );


### PR DESCRIPTION
While I was translating kanboard in italian language, I've found that there were 4 untranslatable strings.
This PR fix that for the main translation language file (fr-FR).