### PR TITLE
Fixing some pathing information for config.php and sqlite DB

### DIFF
--- a/app/check_setup.php
+++ b/app/check_setup.php
@@ -15,8 +15,8 @@ if (version_compare(PHP_VERSION, '5.4.0', '<')) {
 }
 
 // Check data folder if sqlite
-if (DB_DRIVER === 'sqlite' && ! is_writable('data')) {
-    throw new Exception('The directory "data" must be writeable by your web server user');
+if (DB_DRIVER === 'sqlite' && ! is_writable(dirname(DB_FILENAME))) {
+    throw new Exception('The directory "'.dirname(DB_FILENAME).'" must be writeable by your web server user');
 }
 
 // Check PDO extensions

--- a/app/common.php
+++ b/app/common.php
@@ -14,12 +14,12 @@ if (getenv('DATABASE_URL')) {
     define('DB_NAME', ltrim($dbopts["path"], '/'));
 }
 
-if (file_exists('config.php')) {
-    require 'config.php';
+if (file_exists(__DIR__.DIRECTORY_SEPARATOR.'config.php')) {
+    require __DIR__.DIRECTORY_SEPARATOR.'config.php';
 }
 
-if (file_exists('data'.DIRECTORY_SEPARATOR.'config.php')) {
-    require 'data'.DIRECTORY_SEPARATOR.'config.php';
+if (file_exists(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'data'.DIRECTORY_SEPARATOR.'config.php')) {
+    require __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'data'.DIRECTORY_SEPARATOR.'config.php';
 }
 
 require __DIR__.'/constants.php';


### PR DESCRIPTION
We have the use case, where our Kanboard source tree is outside of the docroot.  As a result, our docroot contains only the following:

```
lrwxr-xr-x  1 www  www  13 Apr 13 17:39 assets@ -> ../git/assets
lrwxr-xr-x  1 www  www  16 Apr 13 17:39 index.php@ -> ../git/index.php
lrwxr-xr-x  1 www  www  18 Apr 13 17:39 jsonrpc.php@ -> ../git/jsonrpc.php
```

Prior to this patch, there also had to be a symlink for `data`, as well as the presence of a `config.php`.  With this patch, these resources can live in the source tree directory.  Check my math, however, and make sure that it won't break another use case.