### PR TITLE
Add sqlite2mysql script to FAQ

### DIFF
--- a/doc/faq.markdown
+++ b/doc/faq.markdown
@@ -109,6 +109,7 @@ Where can I find a list of related projects?
 - [Trello import script by @matueranet](https://github.com/matueranet/kanboard-import-trello)
 - [Chrome extension by Timo](https://chrome.google.com/webstore/detail/kanboard-quickmenu/akjbeplnnihghabpgcfmfhfmifjljneh?utm_source=chrome-ntp-icon), [Source code](https://github.com/BlueTeck/kanboard_chrome_extension)
 - [Python client script by @dzudek](https://gist.github.com/fguillot/84c70d4928eb1e0cb374)
+- [Shell script for SQLite to MySQL/MariaDB migration by @oliviermaridat](https://github.com/oliviermaridat/kanboard-sqlite2mysql)
 
 
 Are there some tutorials about Kanboard in other languages?


### PR DESCRIPTION
Just link to https://github.com/oliviermaridat/kanboard-sqlite2mysql in the doc.
