### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/doc/index.markdown
+++ b/doc/index.markdown
@@ -101,6 +101,7 @@ Technical details
 - [Run Kanboard with Docker](docker.markdown)
 - [Run Kanboard with Vagrant](vagrant.markdown)
 - [Run Kanboard on Cloudron](cloudron.markdown)
+- [Run Kanboard on Nitrous](nitrous.markdown)
 
 ### Configuration
 

--- a/doc/nitrous.markdown
+++ b/doc/nitrous.markdown
@@ -1,0 +1,10 @@
+Nitrous Quickstart
+==================
+
+Create a free development environment for this Kanboard project in the cloud on [Nitrous.io](https://www.nitrous.io) by clicking the button below.
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+Simply access your site via the `Preview > 3000` link in the IDE.

--- a/nitrous-post-create.sh
+++ b/nitrous-post-create.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+rm -rf ~/code/public_html
+
+sudo apt-get update
+sudo apt-get install -y php5-sqlite
+sudo apt-get clean
+
+cd ~/code
+mv kanboard public_html
+cd public_html
+composer install
+cd ~/code
+sudo chown -R nitrous:www-data public_html
+sudo service apache2 reload

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,6 @@
+{
+  "template": "php-apache",
+  "ports": [3000],
+  "name": "Kanboard",
+  "description": "Kanban project management software"
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.