### PR TITLE
Add hooks in task sidebar as in user sidebar

### DIFF
--- a/app/Template/task/sidebar.php
+++ b/app/Template/task/sidebar.php
@@ -23,6 +23,8 @@
             <?= $this->url->link(t('Time tracking'), 'task', 'timetracking', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>
         </li>
         <?php endif ?>
+
+        <?= $this->hook->render('template:task:sidebar:information', array('task' => $task)) ?>
     </ul>
 
     <?php if ($this->user->hasProjectAccess('taskmodification', 'edit', $task['project_id'])): ?>
@@ -91,8 +93,8 @@
                 <?= $this->url->link(t('Remove'), 'task', 'remove', array('task_id' => $task['id'], 'project_id' => $task['project_id']), false, 'popover') ?>
             </li>
         <?php endif ?>
+
+        <?= $this->hook->render('template:task:sidebar:actions', array('task' => $task)) ?>
     </ul>
     <?php endif ?>
-
-    <?= $this->hook->render('template:task:sidebar', array('task' => $task)) ?>
 </div>

--- a/doc/plugin-hooks.markdown
+++ b/doc/plugin-hooks.markdown
@@ -174,7 +174,8 @@ List of template hooks:
 | `template:task:details:third-column`       | Task summary third column                          |
 | `template:task:details:fourth-column`      | Task summary fourth column                         |
 | `template:task:dropdown`                   | Task dropdown menu in listing pages                |
-| `template:task:sidebar`                    | Sidebar on task page                               |
+| `template:task:sidebar:actions`            | Sidebar on task page (section actions)             |
+| `template:task:sidebar:information`        | Sidebar on task page (section information)         |
 | `template:task:form:left-column`           | Left column in task form                           |
 | `template:task:form:right-column`          | Right column in task form                          |
 | `template:task:show:top   `                | Show task page: top                                |


### PR DESCRIPTION
This PR removes the existing task sidebar hook `template:task:sidebar` and replace it by two new ones `template:task:sidebar:actions` and `template:task:sidebar:information` (as it is done for the user sidebar).