### PR TITLE
Fix "403 Forbidden" when installed in directory named "kanboard"

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -8,7 +8,7 @@
     RewriteRule ^ index.php [QSA,L]
 </IfModule>
 
-<FilesMatch "(kanboard|config.php|config.default.php)">
+<FilesMatch "(kanboard|config.php|config.default.php)$">
     <IfModule mod_version.c>
         <IfVersion >= 2.3>
             Require all denied


### PR DESCRIPTION
Let's say you're using Apache and you install Kanboard into a directory named "kanboard" (e.g. /var/www/html/kanboard). If you try to access it by using http://example.com/kanboard (note there's no slash at the end) you will get a 403. But if you add a slash to the end (http://example.com/kanboard/) then it works.

This PR fixes the issue by adding `$` to the end of the regex. Now, http://example.com/kanboard will properly redirect to http://example.com/kanboard/, and the files `kanboard`, `config.php`, and `config.default.php` are still given 403s.