### PR TITLE
Fix plural form

### DIFF
--- a/app/Template/column/index.php
+++ b/app/Template/column/index.php
@@ -9,7 +9,7 @@
 </div>
 
 <?php if (empty($columns)): ?>
-    <p class="alert alert-error"><?= t('Your board doesn\'t have any column!') ?></p>
+    <p class="alert alert-error"><?= t('Your board doesn\'t have any columns!') ?></p>
 <?php else: ?>
     <table
         class="columns-table table-stripped"


### PR DESCRIPTION
When removing all columns from a board, an alert box is displayed that
states "Your board doesn't have any column!", the correct plural form
should be "Your board doesn't have any columns!"