### PR TITLE
Fix li element list-style-type

### DIFF
--- a/assets/css/src/tooltip.css
+++ b/assets/css/src/tooltip.css
@@ -68,6 +68,10 @@ div.ui-tooltip {
     margin-bottom: 0px;
 }
 
+.ui-tooltip li {
+  list-style-type: none;
+}
+
 .tooltip .fa-info-circle {
 	color: #999;
 	font-size: 0.95em;


### PR DESCRIPTION
The tooltip was showing a bullet point for an `li` element which was showing up on the outside of the tooltip box. Setting the list-style-type to none removes this bullet point and makes the tooltip look a lot cleaner.

### Before 
![screenshot 2016-06-06 14 26 08](https://cloud.githubusercontent.com/assets/7981032/15839161/be9e0c3c-2bf6-11e6-9834-83af882498ce.png)

### After
![screenshot 2016-06-06 14 52 33](https://cloud.githubusercontent.com/assets/7981032/15839169/c42837e0-2bf6-11e6-8cd1-60f56b1918a1.png)

You can easily confirm that this has the expected behavior by adding the snippet below to the custom stylesheet under application settings. 

```
.ui-tooltip li {
  list-style-type: none;
}
```

