### PR TITLE
Add Alert Box for Empty Public Board

### DIFF
--- a/app/Controller/BoardViewController.php
+++ b/app/Controller/BoardViewController.php
@@ -39,7 +39,7 @@ class BoardViewController extends BaseController
             'board_public_refresh_interval' => $this->configModel->get('board_public_refresh_interval'),
             'board_private_refresh_interval' => $this->configModel->get('board_private_refresh_interval'),
             'board_highlight_period' => $this->configModel->get('board_highlight_period'),
-            'nb_active_tasks' => $taskStats[nb_active_tasks],
+            'nb_active_tasks' => $taskStats['nb_active_tasks'],
         )));
     }
 

--- a/app/Controller/BoardViewController.php
+++ b/app/Controller/BoardViewController.php
@@ -23,6 +23,7 @@ class BoardViewController extends BaseController
     {
         $token = $this->request->getStringParam('token');
         $project = $this->projectModel->getByToken($token);
+        $taskStats = $this->projectModel->getTaskStats($project['id']);
 
         if (empty($project)) {
             throw AccessForbiddenException::getInstance()->withoutLayout();
@@ -38,6 +39,7 @@ class BoardViewController extends BaseController
             'board_public_refresh_interval' => $this->configModel->get('board_public_refresh_interval'),
             'board_private_refresh_interval' => $this->configModel->get('board_private_refresh_interval'),
             'board_highlight_period' => $this->configModel->get('board_highlight_period'),
+            'nb_active_tasks' => $taskStats[nb_active_tasks],
         )));
     }
 

--- a/app/Template/board/view_public.php
+++ b/app/Template/board/view_public.php
@@ -1,6 +1,9 @@
 <section id="main" class="public-board">
 
-   <?= $this->render('board/table_container', array(
+    <?php if (empty($nb_active_tasks)): ?>
+        <p class="alert alert-warning"><?= t('This project does not have any active tasks!') ?></p>
+    <?php endif ?>
+    <?= $this->render('board/table_container', array(
             'project' => $project,
             'swimlanes' => $swimlanes,
             'board_private_refresh_interval' => $board_private_refresh_interval,


### PR DESCRIPTION
If a public board has no open tasks, we now show a notification telling
users that there are no active tasks on this board.

fix #2100

# Screenshot Previews

## New Board with no tasks 
<img width="1051" alt="screenshot 2016-06-08 22 09 10" src="https://cloud.githubusercontent.com/assets/7981032/15919430/1771df5c-2dc6-11e6-8792-45bfecfeb6bb.png">

## New Board with open tasks
<img width="1051" alt="screenshot 2016-06-08 22 09 33" src="https://cloud.githubusercontent.com/assets/7981032/15919433/1fa3370c-2dc6-11e6-8178-92aeeeafe4ad.png">

## New Board with only closed tasks 
<img width="1052" alt="screenshot 2016-06-08 22 09 51" src="https://cloud.githubusercontent.com/assets/7981032/15919435/2a0164bc-2dc6-11e6-8b86-bf5171e9cbbc.png">
