### PR TITLE
Better German

### DIFF
--- a/app/Locale/de_DE/translations.php
+++ b/app/Locale/de_DE/translations.php
@@ -961,7 +961,7 @@ return array(
     'Add group member' => 'Gruppenmitglied hinzufügen',
     'Do you really want to remove this group: "%s"?' => 'Wollen Sie die Gruppe "%s" wirklich löschen?',
     'There is no user in this group.' => 'Es gibt keinen Benutzer in dieser Gruppe.',
-    'Remove this user' => 'Diesen Benutzer löschen',
+    'Remove this user' => 'Diesen Benutzer entfernen',
     'Permissions' => 'Berechtigungen',
     'Allowed Users' => 'Berechtigte Benutzer',
     'No user have been allowed specifically.' => 'Keine Benutzer mit ausdrücklicher Berechtigung.',


### PR DESCRIPTION
"löschen" means "delete". It is not really clear whet Kanboard does when you click on that link. It deletes the user?? No, it just removes it from that group. Maybe that should be named clearer, even in English. IMHO a simple "remove" (in German "entfernen") would do a better job than "remove this user" - because it is divergent.
So I would either use "remove user from group", or (better) just "remove".
Anyway. The German term should be "entfernen", not "löschen"