### PR TITLE
Allow task to be duplicated to another project upon task creation

### DIFF
--- a/app/Action/TaskDuplicateAnotherProject.php
+++ b/app/Action/TaskDuplicateAnotherProject.php
@@ -34,6 +34,7 @@ class TaskDuplicateAnotherProject extends Base
         return array(
             TaskModel::EVENT_MOVE_COLUMN,
             TaskModel::EVENT_CLOSE,
+            TaskModel::EVENT_CREATE,
         );
     }
 


### PR DESCRIPTION
Small modification to enable the TaskDuplicateAnotherProject action to make use of the task creation event.

How might this be used?   I have a column for "Today" tasks in my main project. I have another project specifically for working with my today tasks. The today project has columns for the hours of the day, and I move the tasks into the hours column that I plan to work on them.  The Today project is treated as a workspace, and the main project is the official source.  It's nice to duplicate tasks to the Today project when they are created in the main project's Today column. At the end of each day, the Today project is wiped clean.    

 