### PR TITLE
Hide tasks within specific columns in dashboard

### DIFF
--- a/app/Controller/ColumnController.php
+++ b/app/Controller/ColumnController.php
@@ -66,7 +66,7 @@ class ColumnController extends BaseController
         list($valid, $errors) = $this->columnValidator->validateCreation($values);
 
         if ($valid) {
-            if ($this->columnModel->create($project['id'], $values['title'], $values['task_limit'], $values['description']) !== false) {
+            if ($this->columnModel->create($project['id'], $values['title'], $values['task_limit'], $values['description'], $values['hide_in_dashboard']) !== false) {
                 $this->flash->success(t('Column created successfully.'));
                 return $this->response->redirect($this->helper->url->to('ColumnController', 'index', array('project_id' => $project['id'])), true);
             } else {
@@ -108,10 +108,14 @@ class ColumnController extends BaseController
         $project = $this->getProject();
         $values = $this->request->getValues();
 
+        if (! isset($values['hide_in_dashboard'])) {
+            $values += array('hide_in_dashboard' => 0);
+        }
+
         list($valid, $errors) = $this->columnValidator->validateModification($values);
 
         if ($valid) {
-            if ($this->columnModel->update($values['id'], $values['title'], $values['task_limit'], $values['description'])) {
+            if ($this->columnModel->update($values['id'], $values['title'], $values['task_limit'], $values['description'], $values['hide_in_dashboard'])) {
                 $this->flash->success(t('Board updated successfully.'));
                 return $this->response->redirect($this->helper->url->to('ColumnController', 'index', array('project_id' => $project['id'])));
             } else {

--- a/app/Locale/bs_BA/translations.php
+++ b/app/Locale/bs_BA/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/cs_CZ/translations.php
+++ b/app/Locale/cs_CZ/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/da_DK/translations.php
+++ b/app/Locale/da_DK/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/de_DE/translations.php
+++ b/app/Locale/de_DE/translations.php
@@ -1202,4 +1202,5 @@ return array(
     'Email transport' => 'E-Mail Verkehr',
     'Webhook token' => 'Webhook Token',
     'Imports' => 'Importe',
+    'Hide tasks in this column in the Dashboard' => 'Aufgaben in dieser Spalte im Dashboard ausblenden',
 );

--- a/app/Locale/el_GR/translations.php
+++ b/app/Locale/el_GR/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/es_ES/translations.php
+++ b/app/Locale/es_ES/translations.php
@@ -1202,4 +1202,5 @@ return array(
     'Email transport' => 'Transporte de correo electrónico',
     'Webhook token' => 'Token del disparador web (webhook)',
     'Imports' => 'Importaciones',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/fi_FI/translations.php
+++ b/app/Locale/fi_FI/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/fr_FR/translations.php
+++ b/app/Locale/fr_FR/translations.php
@@ -1203,4 +1203,5 @@ return array(
     'Email transport' => 'Transport des emails',
     'Webhook token' => 'Jeton de sécurité des webhooks',
     'Imports' => 'Importations',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/hu_HU/translations.php
+++ b/app/Locale/hu_HU/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/id_ID/translations.php
+++ b/app/Locale/id_ID/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/it_IT/translations.php
+++ b/app/Locale/it_IT/translations.php
@@ -1202,4 +1202,5 @@ return array(
     'Email transport' => 'Trasporto Email',
     // 'Webhook token' => '',
     'Imports' => 'Importa',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/ja_JP/translations.php
+++ b/app/Locale/ja_JP/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/ko_KR/translations.php
+++ b/app/Locale/ko_KR/translations.php
@@ -1202,4 +1202,5 @@ return array(
     'Email transport' => '이메일 전송',
     // 'Webhook token' => '',
     'Imports' => '가져오기',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/my_MY/translations.php
+++ b/app/Locale/my_MY/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/nb_NO/translations.php
+++ b/app/Locale/nb_NO/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/nl_NL/translations.php
+++ b/app/Locale/nl_NL/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/pl_PL/translations.php
+++ b/app/Locale/pl_PL/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/pt_BR/translations.php
+++ b/app/Locale/pt_BR/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/pt_PT/translations.php
+++ b/app/Locale/pt_PT/translations.php
@@ -1202,4 +1202,5 @@ return array(
     'Email transport' => 'Transportador de Email',
     'Webhook token' => 'Token do Webhook',
     'Imports' => 'Importados',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/ru_RU/translations.php
+++ b/app/Locale/ru_RU/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/sr_Latn_RS/translations.php
+++ b/app/Locale/sr_Latn_RS/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/sv_SE/translations.php
+++ b/app/Locale/sv_SE/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/th_TH/translations.php
+++ b/app/Locale/th_TH/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/tr_TR/translations.php
+++ b/app/Locale/tr_TR/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Locale/zh_CN/translations.php
+++ b/app/Locale/zh_CN/translations.php
@@ -1202,4 +1202,5 @@ return array(
     // 'Email transport' => '',
     // 'Webhook token' => '',
     // 'Imports' => '',
+    //'Hide tasks in this column in the Dashboard' => '',
 );

--- a/app/Model/ColumnModel.php
+++ b/app/Model/ColumnModel.php
@@ -132,13 +132,14 @@ class ColumnModel extends Base
      * @param  string    $description   Column description
      * @return boolean|integer
      */
-    public function create($project_id, $title, $task_limit = 0, $description = '')
+    public function create($project_id, $title, $task_limit = 0, $description = '', $hide_in_dashboard = 0)
     {
         $values = array(
             'project_id' => $project_id,
             'title' => $title,
             'task_limit' => intval($task_limit),
             'position' => $this->getLastColumnPosition($project_id) + 1,
+            'hide_in_dashboard' => $hide_in_dashboard,
             'description' => $description,
         );
 
@@ -155,11 +156,12 @@ class ColumnModel extends Base
      * @param  string    $description   Optional description
      * @return boolean
      */
-    public function update($column_id, $title, $task_limit = 0, $description = '')
+    public function update($column_id, $title, $task_limit = 0, $description = '', $hide_in_dashboard = 0)
     {
         return $this->db->table(self::TABLE)->eq('id', $column_id)->update(array(
             'title' => $title,
             'task_limit' => intval($task_limit),
+            'hide_in_dashboard' => $hide_in_dashboard,
             'description' => $description,
         ));
     }

--- a/app/Model/TaskFinderModel.php
+++ b/app/Model/TaskFinderModel.php
@@ -81,7 +81,8 @@ class TaskFinderModel extends Base
                     ->join(ColumnModel::TABLE, 'id', 'column_id')
                     ->eq(TaskModel::TABLE.'.owner_id', $user_id)
                     ->eq(TaskModel::TABLE.'.is_active', TaskModel::STATUS_OPEN)
-                    ->eq(ProjectModel::TABLE.'.is_active', ProjectModel::ACTIVE);
+                    ->eq(ProjectModel::TABLE.'.is_active', ProjectModel::ACTIVE)
+                    ->eq(ColumnModel::TABLE.'.hide_in_dashboard', 0);
     }
 
     /**

--- a/app/Schema/Mysql.php
+++ b/app/Schema/Mysql.php
@@ -6,7 +6,12 @@ use PDO;
 use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 
-const VERSION = 110;
+const VERSION = 111;
+
+function version_111(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE columns ADD COLUMN hide_in_dashboard INT DEFAULT 0 NOT NULL');
+}
 
 function version_110(PDO $pdo)
 {

--- a/app/Schema/Postgres.php
+++ b/app/Schema/Postgres.php
@@ -6,7 +6,12 @@ use PDO;
 use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 
-const VERSION = 89;
+const VERSION = 90;
+
+function version_90(PDO $pdo)
+{
+    $pdo->exec("ALTER TABLE columns ADD COLUMN hide_in_dashboard INTEGER DEFAULT 0 NOT NULL");
+}
 
 function version_89(PDO $pdo)
 {

--- a/app/Schema/Sql/mysql.sql
+++ b/app/Schema/Sql/mysql.sql
@@ -44,6 +44,7 @@ CREATE TABLE `columns` (
   `position` int(11) NOT NULL,
   `project_id` int(11) NOT NULL,
   `task_limit` int(11) DEFAULT '0',
+  `hide_in_dashboard` int(11) DEFAULT '0',
   `description` text,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_title_project` (`title`,`project_id`),

--- a/app/Schema/Sql/postgres.sql
+++ b/app/Schema/Sql/postgres.sql
@@ -98,6 +98,7 @@ CREATE TABLE "columns" (
     "position" integer,
     "project_id" integer NOT NULL,
     "task_limit" integer DEFAULT 0,
+    "hide_in_dashboard" integer DEFAULT 0,
     "description" "text"
 );
 

--- a/app/Schema/Sqlite.php
+++ b/app/Schema/Sqlite.php
@@ -6,7 +6,12 @@ use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 use PDO;
 
-const VERSION = 101;
+const VERSION = 102;
+
+function version_102(PDO $pdo)
+{
+    $pdo->exec("ALTER TABLE columns ADD COLUMN hide_in_dashboard INTEGER DEFAULT 0 NOT NULL");
+}
 
 function version_101(PDO $pdo)
 {

--- a/app/Template/column/create.php
+++ b/app/Template/column/create.php
@@ -13,6 +13,8 @@
     <?= $this->form->label(t('Task limit'), 'task_limit') ?>
     <?= $this->form->number('task_limit', $values, $errors) ?>
 
+    <?= $this->form->checkbox('hide_in_dashboard', t('Hide tasks in this column in the Dashboard'), 1) ?>
+
     <?= $this->form->label(t('Description'), 'description') ?>
     <?= $this->form->textarea('description', $values, $errors, array(), 'markdown-editor') ?>
 

--- a/app/Template/column/edit.php
+++ b/app/Template/column/edit.php
@@ -15,6 +15,8 @@
     <?= $this->form->label(t('Task limit'), 'task_limit') ?>
     <?= $this->form->number('task_limit', $values, $errors) ?>
 
+    <?= $this->form->checkbox('hide_in_dashboard', t('Hide tasks in this column in the Dashboard'), 1, $values['hide_in_dashboard'] == 1) ?>
+
     <?= $this->form->label(t('Description'), 'description') ?>
     <?= $this->form->textarea('description', $values, $errors, array(), 'markdown-editor') ?>
 

--- a/app/Template/project_view/show.php
+++ b/app/Template/project_view/show.php
@@ -54,9 +54,10 @@
 </div>
 <table class="table-stripped">
     <tr>
-        <th class="column-60"><?= t('Column') ?></th>
+        <th class="column-40"><?= t('Column') ?></th>
         <th class="column-20"><?= t('Task limit') ?></th>
         <th class="column-20"><?= t('Active tasks') ?></th>
+        <th class="column-20"><?= t('Hide tasks in this column in the Dashboard') ?></th>
     </tr>
     <?php foreach ($stats['columns'] as $column): ?>
     <tr>
@@ -70,6 +71,13 @@
         </td>
         <td><?= $column['task_limit'] ?: '∞' ?></td>
         <td><?= $column['nb_active_tasks'] ?></td>
+        <td>
+        <?php if ($column['hide_in_dashboard'] == 1): ?>
+            <?= t('Yes') ?>
+        <?php else: ?>
+            <?= t('No') ?>
+        <?php endif ?>
+        </td>
     </tr>
     <?php endforeach ?>
 </table>


### PR DESCRIPTION
If you have a column in your board, lets say backlog, with tasks not started yet, you can hide the tasks in this column from the dashboard overview with this PR.

The edit and create dialog for columns have a new checkbox:
![edit](https://cloud.githubusercontent.com/assets/12938119/16268883/696a6890-3890-11e6-96c0-91964c7dbaa9.jpg)

In the project summary you can see the status of the columns:
![summary](https://cloud.githubusercontent.com/assets/12938119/16268906/8174e9a6-3890-11e6-92b4-5377bb6aceb5.jpg)

In the dashboard the task from column backlog is not shown:
![dashboard](https://cloud.githubusercontent.com/assets/12938119/16268970/ca1783c6-3890-11e6-8f01-43736f0b993e.jpg)


But in the board view you can see it:
![board](https://cloud.githubusercontent.com/assets/12938119/16268955/b96090cc-3890-11e6-93c2-7145d5195776.jpg)
