### PR TITLE
API project - Add Owner_id and identifier feature

### DIFF
--- a/app/Api/ProjectApi.php
+++ b/app/Api/ProjectApi.php
@@ -89,6 +89,6 @@ class ProjectApi extends BaseApi
         );
 
         list($valid, ) = $this->projectValidator->validateModification($values);
-        return $valid && $this->projectModel->update($values, $owner_id);
+        return $valid && $this->projectModel->update($values);
     }
 }

--- a/app/Api/ProjectApi.php
+++ b/app/Api/ProjectApi.php
@@ -67,7 +67,7 @@ class ProjectApi extends BaseApi
         return $this->helper->projectActivity->getProjectEvents($project_id);
     }
 
-    public function createProject($name, $description = null, $owner_id=0, $identifier=null)
+    public function createProject($name, $description = null, $owner_id = 0, $identifier = null)
     {
         $values = array(
             'name' => $name,
@@ -79,7 +79,7 @@ class ProjectApi extends BaseApi
         return $valid ? $this->projectModel->create($values, $owner_id) : false;
     }
 
-    public function updateProject($id, $name, $description = null, $owner_id=0,  $identifier=null)
+    public function updateProject($id, $name, $description = null,  $identifier = null)
     {
         $values = array(
             'id' => $id,

--- a/app/Api/ProjectApi.php
+++ b/app/Api/ProjectApi.php
@@ -21,6 +21,11 @@ class ProjectApi extends BaseApi
         return $this->formatProject($this->projectModel->getByName($name));
     }
 
+    public function getProjectByIdentifier($identifier)
+    {
+        return $this->formatProject($this->projectModel->getByIdentifier($identifier));
+    }
+
     public function getAllProjects()
     {
         return $this->formatProjects($this->projectModel->getAll());
@@ -62,26 +67,28 @@ class ProjectApi extends BaseApi
         return $this->helper->projectActivity->getProjectEvents($project_id);
     }
 
-    public function createProject($name, $description = null)
+    public function createProject($name, $description = null, $owner_id=0, $identifier=null)
     {
         $values = array(
             'name' => $name,
-            'description' => $description
+            'description' => $description,
+            'identifier' => $identifier
         );
 
         list($valid, ) = $this->projectValidator->validateCreation($values);
-        return $valid ? $this->projectModel->create($values) : false;
+        return $valid ? $this->projectModel->create($values, $owner_id) : false;
     }
 
-    public function updateProject($id, $name, $description = null)
+    public function updateProject($id, $name, $description = null, $owner_id=0,  $identifier=null)
     {
         $values = array(
             'id' => $id,
             'name' => $name,
-            'description' => $description
+            'description' => $description,
+            'identifier' => $identifier
         );
 
         list($valid, ) = $this->projectValidator->validateModification($values);
-        return $valid && $this->projectModel->update($values);
+        return $valid && $this->projectModel->update($values, $owner_id);
     }
 }


### PR DESCRIPTION
Hi there,
We are using Kanboard to create projects/tasks automaticity from an external source, so we have an external id used to create and get them.
With this pull request your are able to create and update project with two more options :
 - owner_id
 - identifier

A new useful project API method getProjectByIdentifier has been had to app/Api/ProjectApi.php

Thx.