### PR TITLE
Fixed "due today" highlighting

### DIFF
--- a/app/Template/board/task_footer.php
+++ b/app/Template/board/task_footer.php
@@ -37,7 +37,7 @@
     <?php endif ?>
 
     <?php if (! empty($task['date_due'])): ?>
-        <?php if (date('d') == date('d', $task['date_due'])): ?>
+        <?php if (date('Y-m-d') == date('Y-m-d', $task['date_due'])): ?>
         <span class="task-board-date task-board-date-today">
         <?php elseif (time() > $task['date_due']): ?>
         <span class="task-board-date task-board-date-overdue">


### PR DESCRIPTION
The highlighting for "due date" = today ignores the month and year.
So e.g. a task due on 03.08.2016 is also colored blue today (03.07.2016).
I considered this a bug and changed the behaviour.