### PR TITLE
ProjectPermissionController: make sure groups don't exist before creating them

### DIFF
--- a/app/Controller/ProjectPermissionController.php
+++ b/app/Controller/ProjectPermissionController.php
@@ -147,7 +147,13 @@ class ProjectPermissionController extends BaseController
         $values = $this->request->getValues();
 
         if (empty($values['group_id']) && ! empty($values['external_id'])) {
-            $values['group_id'] = $this->groupModel->create($values['name'], $values['external_id']);
+            $group = $this->groupModel->getByExternalId($values['external_id']);
+            if ($group) {
+                $values['group_id'] = $group['id'];
+            }
+            else {
+                $values['group_id'] = $this->groupModel->create($values['name'], $values['external_id']);
+            }
         }
 
         if ($this->projectGroupRoleModel->addGroup($project['id'], $values['group_id'], $values['role'])) {


### PR DESCRIPTION
We were hitting a bug, where external groups that existed in the groups table, were failing to add to projects.  It appears that this is because a blank id passed to ProjectPermissionController/addGroup will simply try to create the group in the groups table, rather than try to look it up by external ID.